### PR TITLE
Add support for chart type geo.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -158,6 +158,21 @@
            ["Fri", 68, 15, 66]]'>
   </google-chart>
 
+  <p>Here's a geo chart:</p>
+
+  <google-chart
+    type='geo'
+    height='300px'
+    width='400px'
+    data='[["Country", "Popularity"],
+           ["Germany", 200],
+           ["United States", 300],
+           ["Brazil", 400],
+           ["Canada", 500],
+           ["France", 600],
+           ["RU", 700]]'>
+  </google-chart>
+
   <p>Here's a histogram:</p>
 
   <google-chart

--- a/google-chart.html
+++ b/google-chart.html
@@ -62,7 +62,7 @@ Data can be provided in one of three ways:
        * Sets the type of the chart.
        *
        * Should be one of:
-       * - `area`, `bar`, `bubble`, `candlestick`, `column`, `combo`,
+       * - `area`, `bar`, `bubble`, `candlestick`, `column`, `combo`, `geo`,
        *   `histogram`, `line`, `pie`, `scatter`, `stepped-area`
        *
        * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a> for details.
@@ -227,6 +227,7 @@ Data can be provided in one of three ways:
           'candlestick': google.visualization.CandlestickChart,
           'column': google.visualization.ColumnChart,
           'combo': google.visualization.ComboChart,
+          'geo': google.visualization.GeoChart,
           'histogram': google.visualization.Histogram,
           'line': google.visualization.LineChart,
           'pie': google.visualization.PieChart,


### PR DESCRIPTION
I'd like this for some of the analytics chart demos, which I'm refactoring to use `<google-chart>` instead of the native library.
