### PR TITLE
set text stroke-width to 0 for legend labels

### DIFF
--- a/google-chart.html
+++ b/google-chart.html
@@ -43,6 +43,10 @@ Data can be provided in one of three ways:
       :host {
         display: block;
       }
+
+      text {
+        stroke-width: 0;
+      }
     </style>
     <core-ajax id="ajax" handleAs="json" url="{{data}}"
       on-core-response="{{externalDataLoaded}}"></core-ajax>


### PR DESCRIPTION
I'd like the default stroke-width for text svgs to be 0, in order to solve [issue #11](https://github.com/GoogleWebComponents/google-chart/issues/11).
