### PR TITLE
Switching to style attributes for height and width.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -8,7 +8,15 @@
   <script src="../platform/platform.js"></script>
   <link rel="import" href="google-chart.html">
   <style>
-    code { color: #007000; }
+    code {
+      color: #007000;
+    }
+
+    google-chart {
+      height: 300px;
+      width: 400px;
+    }
+
   </style>
 
 </head>
@@ -21,13 +29,46 @@
     rows='[["Something", 1]]'>
   </google-chart>
 
+  <p>Charts can be resized with CSS, but you'll need to call the <code>drawChart</code> method when the size changes.</p>
+  <p>Here's a basic responsive example using only CSS and JS. You could also use <code>&lt;core-media-query&gt;</code>.</p>
+
+  <style>
+    /* Phone and tablet */
+    #resizing_chart {
+      height: 300px;
+      width: 400px;
+    }
+
+    /* Desktop */
+    @media screen and (min-width: 1024px) {
+      #resizing_chart {
+        width: 800px;
+      }
+    }
+  </style>
+
+  <script>
+    var media = window.matchMedia('(min-width: 1024px)');
+
+    media.addListener(function() {
+      document.getElementById('resizing_chart').drawChart();
+    });
+  </script>
+
+  <google-chart
+    id='resizing_chart'
+    type='column'
+    options='{"title": "Responsive chart",
+              "vAxis": {"minValue" : 0, "maxValue": 10}}'
+    cols='[{"label": "Data", "type": "string"},{"label": "Value", "type": "number"}]'
+    rows='[["Col1", 5.0],["Col2", 5.0],["Col3", 5.0]]'>
+  </google-chart>
+
   <p>Here's a chart that changes data every 3 seconds:</p>
 
   <google-chart
     id='mutating_chart'
     type='column'
-    height='300px'
-    width='400px'
     options='{"title": "Random data",
               "vAxis": {"minValue" : 0, "maxValue": 10},
               "animation": {"duration": "1000"}}'
@@ -53,8 +94,6 @@
 
   <google-chart
     type='column'
-    height='300px'
-    width='400px'
     options='{"title": "Inventory"}'
     data='[["Year", "Things", "Stuff"],
            ["2004", 1000, 400],
@@ -67,8 +106,6 @@
 
   <google-chart
     type='column'
-    height='300px'
-    width='400px'
     options='{"title": "Bar height", "legend": "none"}'
     data='chart-data.json'>
   </google-chart>
@@ -77,8 +114,6 @@
 
   <google-chart
     type='column'
-    height='300px'
-    width='400px'
     options='{"title": "Visitors by Country", "legend": "none"}'
     data='country-data.json'>
   </google-chart>
@@ -89,8 +124,6 @@
 
   <google-chart
     type='area'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -100,8 +133,6 @@
 
   <google-chart
     type='bar'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -111,8 +142,6 @@
 
   <google-chart
     type='bubble'
-    height='300px'
-    width='400px'
     options='{}'
     data='[["ID", "Life Expectancy", "Fertility Rate", "Region", "Population"],
            ["CAN", 80.66, 1.67, "North America", 33739900],
@@ -131,8 +160,6 @@
 
   <google-chart
     type='candlestick'
-    height='300px'
-    width='400px'
     options='{"legend": "none"}'
     data='[["Day", "low", "start", "end", "high"],
            ["Mon", 20, 28, 38, 45],
@@ -146,8 +173,6 @@
 
   <google-chart
     type='column'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -157,8 +182,6 @@
 
   <google-chart
     type='combo'
-    height='300px'
-    width='400px'
     options='{"seriesType": "bars", "series": {"2": {"type": "line"}}}'
     data='[["Day", "A", "B", "C"],
            ["Mon", 20, 45, 28],
@@ -172,8 +195,6 @@
 
   <google-chart
     type='geo'
-    height='300px'
-    width='400px'
     data='[["Country", "Popularity"],
            ["Germany", 200],
            ["United States", 300],
@@ -187,8 +208,6 @@
 
   <google-chart
     type='histogram'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month", "legend": "none", "histogram": { "bucketSize": 1 }}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -198,8 +217,6 @@
 
   <google-chart
     type='line'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -209,8 +226,6 @@
 
   <google-chart
     type='pie'
-    height='300px'
-    width='400px'
     options='{"title": "Distribution of days in 2001H1"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
@@ -220,8 +235,6 @@
 
   <google-chart
     type='scatter'
-    height='300px'
-    width='400px'
     options='{"legend": "none"}'
     data='[["A", "B"],
            [20, 45],
@@ -235,8 +248,6 @@
 
   <google-chart
     type='stepped-area'
-    height='300px'
-    width='400px'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>

--- a/google-chart.css
+++ b/google-chart.css
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+  margin: 0;
+  padding: 0;
+  width: 400px;
+  height: 300px;
+}
+
+#chartdiv {
+  width: 100%;
+  height: 100%;
+  min-width: 100%;
+  min-height: 100%;
+}

--- a/google-chart.html
+++ b/google-chart.html
@@ -9,12 +9,17 @@ number of ready-to-use chart types.
 
     <google-chart
       type='pie'
-      height='300px'
-      width='400px'
       options='{"title": "Distribution of days in 2001Q1"}'
       cols='[{"label":"Month", "type":"string"}, {"label":"Days", "type":"number"}]'
       rows='[["Jan", 31],["Feb", 28],["Mar", 31]]'>
     </google-chart>
+
+Height and width are specified as style attributes:
+
+    google-chart {
+      height: 300px;
+      width: 50em;
+    }
 
 Data can be provided in one of three ways:
 
@@ -39,259 +44,266 @@ Data can be provided in one of three ways:
 <polymer-element name="google-chart" attributes="type width height options cols rows data">
 
   <template>
-    <style>
-      :host {
-        display: block;
-      }
-    </style>
+    <link rel="stylesheet" href="google-chart.css">
     <core-ajax id="ajax" handleAs="json" url="{{data}}"
       on-core-response="{{externalDataLoaded}}"></core-ajax>
-    <div id="chartdiv" style="width: {{width}}; height: {{height}};
-      min-width: {{width}}; min-height: {{height}}; text-align: center;"></div>
+    <div id="chartdiv"></div>
     <google-jsapi on-api-load="{{readyForAction}}"></google-jsapi>
   </template>
 
   <script>
-    Polymer({
-      /**
-       * Fired when the graph is displayed.
-       *
-       * @event google-chart-render
-       */
+    (function() {
+      'use strict';
+
+      Polymer({
+        /**
+         * Fired when the graph is displayed.
+         *
+         * @event google-chart-render
+         */
 
 
-      /**
-       * Sets the type of the chart.
-       *
-       * Should be one of:
-       * - `area`, `bar`, `bubble`, `candlestick`, `column`, `combo`, `geo`,
-       *   `histogram`, `line`, `pie`, `scatter`, `stepped-area`
-       *
-       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a> for details.
-       *
-       * @attribute type
-       * @type string
-       */
-      type: 'column',
+        /**
+         * Sets the type of the chart.
+         *
+         * Should be one of:
+         * - `area`, `bar`, `bubble`, `candlestick`, `column`, `combo`, `geo`,
+         *   `histogram`, `line`, `pie`, `scatter`, `stepped-area`
+         *
+         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a> for details.
+         *
+         * @attribute type
+         * @type string
+         */
+        type: 'column',
 
-      /**
-       * Sets the width of the chart on the page.
-       *
-       * @attribute width
-       * @type string
-       */
-      width: '400px',
+        /**
+         * Sets the options for the chart.
+         *
+         * Example:
+         * <pre>{
+         *   title: "Chart title goes here",
+         *   hAxis: {title: "Categories"},
+         *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
+         *   legend: "none"
+         * };</pre>
+         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
+         * for the options available to each chart type.
+         *
+         * @attribute options
+         * @type object
+         */
+        options: null,
 
-      /**
-       * Sets the height of the chart on the page.
-       *
-       * @attribute height
-       * @type string
-       */
-      height: '300px',
+        /**
+         * Sets the data columns for this object.
+         *
+         * When specifying data with `cols` you must also specify `rows`, and
+         * not specify `data`.
+         *
+         * Example:
+         * <pre>[{label: "Categories", type: "string"},
+         *  {label: "Value", type: "number"}]</pre>
+         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
+         * for column definition format.
+         *
+         * @attribute cols
+         * @type array
+         */
+        cols: null,
 
-      /**
-       * Sets the options for the chart.
-       *
-       * Example:
-       * <pre>{
-       *   title: "Chart title goes here",
-       *   hAxis: {title: "Categories"},
-       *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
-       *   legend: "none"
-       * };</pre>
-       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
-       * for the options available to each chart type.
-       *
-       * @attribute options
-       * @type object
-       */
-      options: null,
+        /**
+         * Sets the data rows for this object.
+         *
+         * When specifying data with `rows` you must also specify `cols`, and
+         * not specify `data`.
+         *
+         * Example:
+         * <pre>[["Category 1", 1.0],
+         *  ["Category 2", 1.1]]</pre>
+         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
+         * for row format.
+         *
+         * @attribute rows
+         * @type array
+         */
+        rows: null,
 
-      /**
-       * Sets the data columns for this object.
-       *
-       * When specifying data with `cols` you must also specify `rows`, and
-       * not specify `data`.
-       *
-       * Example:
-       * <pre>[{label: "Categories", type: "string"},
-       *  {label: "Value", type: "number"}]</pre>
-       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
-       * for column definition format.
-       *
-       * @attribute cols
-       * @type array
-       */
-      cols: null,
+        /**
+         * Sets the entire dataset for this object.
+         * Can be used to provide the data directly, or to provide a URL from
+         * which to request the data.
+         *
+         * The data format can be a two-dimensional array or the DataTable format
+         * expected by Google Charts.
+         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
+         * for data table format details.
+         *
+         * When specifying data with `data` you must not specify `cols` or `rows`.
+         *
+         * Example:
+         * <pre>[["Categories", "Value"],
+         *  ["Category 1", 1.0],
+         *  ["Category 2", 1.1]]</pre>
+         *
+         * @attribute data
+         * @type array, object, or string
+         */
+        data: null,
 
-      /**
-       * Sets the data rows for this object.
-       *
-       * When specifying data with `rows` you must also specify `cols`, and
-       * not specify `data`.
-       *
-       * Example:
-       * <pre>[["Category 1", 1.0],
-       *  ["Category 2", 1.1]]</pre>
-       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
-       * for row format.
-       *
-       * @attribute rows
-       * @type array
-       */
-      rows: null,
+        chartTypes: null,
 
-      /**
-       * Sets the entire dataset for this object.
-       * Can be used to provide the data directly, or to provide a URL from
-       * which to request the data.
-       *
-       * The data format can be a two-dimensional array or the DataTable format
-       * expected by Google Charts.
-       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
-       * for data table format details.
-       *
-       * When specifying data with `data` you must not specify `cols` or `rows`.
-       *
-       * Example:
-       * <pre>[["Categories", "Value"],
-       *  ["Category 1", 1.0],
-       *  ["Category 2", 1.1]]</pre>
-       *
-       * @attribute data
-       * @type array, object, or string
-       */
-      data: null,
+        chartObject: null,
 
-      chartTypes: null,
+        isReady: false,
 
-      chartObject: null,
+        canDraw: false,
 
-      isReady: false,
+        dataTable: null,
 
-      created: function() {
-        this.chartTypes = {};
-        this.cols = [];
-        this.data = [];
-        this.options = {};
-        this.rows = [];
-      },
-
-      readyForAction: function(e, detail, sender) {
-        google.load("visualization", "1", {
-          packages: ['corechart'],
-          callback: function() {
-            this.isReady = true;
-            this.loadChartTypes();
-            this.loadData();
-          }.bind(this)
-        });
-      },
-
-      typeChanged: function() {
-        // Invalidate current chart object.
-        this.chartObject = null;
-        this.loadData();
-      },
-
-      observe: {
-        rows: 'loadData',
-        cols: 'loadData',
-        data: 'loadData',
-      },
-
-      drawChart: function(dataTable) {
-        if (!this.options) {
+        created: function() {
+          this.chartTypes = {};
+          this.cols = [];
+          this.data = [];
           this.options = {};
-        }
-        if (!this.chartObject) {
-          var chartClass = this.chartTypes[this.type];
-          if (chartClass) {
-            this.chartObject = new chartClass(this.$.chartdiv);
+          this.rows = [];
+          this.dataTable = null;
+        },
+
+        readyForAction: function(e, detail, sender) {
+          google.load("visualization", "1", {
+            packages: ['corechart'],
+            callback: function() {
+              this.isReady = true;
+              this.loadChartTypes();
+              this.loadData();
+            }.bind(this)
+          });
+        },
+
+        typeChanged: function() {
+          // Invalidate current chart object.
+          this.chartObject = null;
+          this.loadData();
+        },
+
+        observe: {
+          rows: 'loadData',
+          cols: 'loadData',
+          data: 'loadData'
+        },
+
+        /**
+         * Draws the chart.
+         *
+         * Called automatically on first load and whenever one of the attributes
+         * changes. Can be called manually to handle e.g. page resizes.
+         *
+         * @method drawChart
+         * @return {Object} Returns null.
+         */
+        drawChart: function() {
+          if (this.canDraw) {
+            if (!this.options) {
+              this.options = {};
+            }
+            if (!this.chartObject) {
+              var chartClass = this.chartTypes[this.type];
+              if (chartClass) {
+                this.chartObject = new chartClass(this.$.chartdiv);
+              }
+            }
+            if (this.chartObject) {
+              this.chartObject.draw(this.dataTable, this.options);
+              google.visualization.events.addOneTimeListener(this.chartObject,
+                  'ready', function() {
+                      this.fire('google-chart-render');
+                  }.bind(this));
+            } else {
+              this.$.chartdiv.innerHTML = 'Undefined chart type';
+            }
           }
-        }
-        if (this.chartObject) {
-          this.chartObject.draw(dataTable, this.options);
-          google.visualization.events.addOneTimeListener(this.chartObject,
-              'ready', function() {
-                  this.fire('google-chart-render');
-              }.bind(this));
-        } else {
-          this.$.chartdiv.innerHTML = 'Undefined chart type';
-        }
-      },
+          return null;
+        },
 
-      loadChartTypes: function() {
-        this.chartTypes = {
-          'area': google.visualization.AreaChart,
-          'bar': google.visualization.BarChart,
-          'bubble': google.visualization.BubbleChart,
-          'candlestick': google.visualization.CandlestickChart,
-          'column': google.visualization.ColumnChart,
-          'combo': google.visualization.ComboChart,
-          'geo': google.visualization.GeoChart,
-          'histogram': google.visualization.Histogram,
-          'line': google.visualization.LineChart,
-          'pie': google.visualization.PieChart,
-          'scatter': google.visualization.ScatterChart,
-          'stepped-area': google.visualization.SteppedAreaChart
-        };
-      },
+        loadChartTypes: function() {
+          this.chartTypes = {
+            'area': google.visualization.AreaChart,
+            'bar': google.visualization.BarChart,
+            'bubble': google.visualization.BubbleChart,
+            'candlestick': google.visualization.CandlestickChart,
+            'column': google.visualization.ColumnChart,
+            'combo': google.visualization.ComboChart,
+            'geo': google.visualization.GeoChart,
+            'histogram': google.visualization.Histogram,
+            'line': google.visualization.LineChart,
+            'pie': google.visualization.PieChart,
+            'scatter': google.visualization.ScatterChart,
+            'stepped-area': google.visualization.SteppedAreaChart
+          };
+        },
 
-      loadData: function() {
-        if (this.isReady) {
-          if (typeof this.data == 'string' || this.data instanceof String) {
-            // Load data asynchronously, from external URL.
-            this.$.ajax.go();
+        loadData: function() {
+          this.canDraw = false;
+          if (this.isReady) {
+            if (typeof this.data == 'string' || this.data instanceof String) {
+              // Load data asynchronously, from external URL.
+              this.$.ajax.go();
+            } else {
+              var dataTable = this.createDataTable();
+              this.canDraw = true;
+              if (dataTable) {
+                this.dataTable = dataTable;
+                this.drawChart();
+              }
+            }
+          }
+        },
+
+        externalDataLoaded: function(e, detail, sender) {
+          var dataTable = this.createDataTable(this.$.ajax.response);
+          this.canDraw = true;
+          this.dataTable = dataTable;
+          this.drawChart();
+        },
+
+        createDataTable: function(data) {
+          var dataTable = null;
+
+          // If a data object was not passed to this function, default to the
+          // chart's data attribute. Passing a data object is necessary for
+          // cases when the data attribute is a URL pointing to an external
+          // data source.
+          if (!data) {
+            data = this.data;
+          }
+
+          if (this.rows && this.rows.length > 0 && this.cols &&
+              this.cols.length > 0) {
+            // Create the data table from cols and rows.
+            dataTable = new google.visualization.DataTable();
+            dataTable.cols = this.cols;
+
+            for (var i = 0; i < this.cols.length; i++) {
+              dataTable.addColumn(this.cols[i]);
+            }
+
+            dataTable.addRows(this.rows);
           } else {
-            var dataTable = this.createDataTable();
-            if (dataTable) this.drawChart(dataTable);
-          }
-        }
-      },
-
-      externalDataLoaded: function(e, detail, sender) {
-        var dataTable = this.createDataTable(this.$.ajax.response);
-        this.drawChart(dataTable);
-      },
-
-      createDataTable: function(data) {
-        var dataTable = null;
-
-        // If a data object was not passed to this function, default to the
-        // chart's data attribute. Passing a data object is necessary for
-        // cases when the data attribute is a URL pointing to an external
-        // data source.
-        if (!data) {
-          data = this.data;
-        }
-
-        if (this.rows && this.rows.length > 0 && this.cols &&
-            this.cols.length > 0) {
-          // Create the data table from cols and rows.
-          dataTable = new google.visualization.DataTable();
-          dataTable.cols = this.cols;
-
-          for (var i = 0; i < this.cols.length; i++) {
-            dataTable.addColumn(this.cols[i]);
+            // Create dataTable from the passed data or the data attribute.
+            // Data can be in the form of raw DataTable data or a two dimensional
+            // array.
+            if (data.rows && data.cols) {
+              dataTable = new google.visualization.DataTable(data);
+            } else if (data.length > 0) {
+              dataTable = google.visualization.arrayToDataTable(data);
+            }
           }
 
-          dataTable.addRows(this.rows);
-        } else {
-          // Create dataTable from the passed data or the data attribute.
-          // Data can be in the form of raw DataTable data or a two dimensional
-          // array.
-          if (data.rows && data.cols) {
-            dataTable = new google.visualization.DataTable(data);
-          } else if (data.length > 0) {
-            dataTable = google.visualization.arrayToDataTable(data);
-          }
+          return dataTable;
         }
-
-        return dataTable;
-      }
-    });
+      });
+    })();
   </script>
 
 </polymer-element>


### PR DESCRIPTION
We should be using standard attributes wherever possible, and this enables CSS-based responsive design (provided that the `drawChart` method is called on media changes, see demo).

@addyosmani @ebidel Mind taking a look? Wrapping everything in an IIFE seems to have messed up the diff, sorry about that.
