### PR TITLE
Use flexbox to make sizing more reliable.

### DIFF
--- a/google-chart.css
+++ b/google-chart.css
@@ -1,5 +1,7 @@
 :host {
-  display: block;
+  display: -webkit-flex;
+  display: -ms-flex;
+  display: flex;
   margin: 0;
   padding: 0;
   width: 400px;
@@ -8,7 +10,4 @@
 
 #chartdiv {
   width: 100%;
-  height: 100%;
-  min-width: 100%;
-  min-height: 100%;
 }

--- a/google-chart.html
+++ b/google-chart.html
@@ -41,7 +41,7 @@ Data can be provided in one of three ways:
 @status alpha
 @homepage http://googlewebcomponents.github.io/google-chart
 -->
-<polymer-element name="google-chart" attributes="type width height options cols rows data selection">
+<polymer-element name="google-chart" attributes="type options cols rows data selection">
 
   <template>
     <link rel="stylesheet" href="google-chart.css">


### PR DESCRIPTION
Setting `height:100%` is an unreliable way to size an element based on its container. If the `<google-chart>` element is a flex item and its height is determined dynamically via the flex layout algorithm, the `height:100%` declaration on the `#chartdiv` element will resolve to zero. This fixes that by using flexbox to size `#chartdiv`.

Also, I noticed the `width` and `height` attributes were mistakenly left on `<google-chart>`.