### PR TITLE
Adding style for gauge element

### DIFF
--- a/google-chart.css
+++ b/google-chart.css
@@ -8,6 +8,11 @@
   height: 300px;
 }
 
+:host([type="gauge"]) {
+  width: 300px;
+  height: 300px;
+}
+
 #chartdiv {
   width: 100%;
 }


### PR DESCRIPTION
A gauge element has a square area, therefor the default width is to big.