### PR TITLE
Add support to format numbers in tooltips

### DIFF
--- a/google-chart.html
+++ b/google-chart.html
@@ -41,7 +41,7 @@ Data can be provided in one of three ways:
 @status alpha
 @homepage http://googlewebcomponents.github.io/google-chart
 -->
-<polymer-element name="google-chart" attributes="type options cols rows data selection">
+<polymer-element name="google-chart" attributes="type options cols rows data selection numberFormats">
 
   <template>
     <link rel="stylesheet" href="google-chart.css">
@@ -177,6 +177,25 @@ Data can be provided in one of three ways:
          * @type array
          */
         selection: [],
+
+        /**
+         * Sets the format for numbers shown in the tooltip.
+         *
+         * An array of objects, each with:
+         *   - a required `col` property (zero-based column number to which formatting applies)
+         *   - optional NumberFormat properties (`decimalSymbol`, `fractionDigits`, `groupingSymbol`, `negativeColor`, `negativeParens`, `pattern`, `prefix`, `suffix`)
+         * 
+         * See <a href="https://developers.google.com/chart/interactive/docs/reference#numberformatter">Google Visualization API reference (NumberFormat)</a> for details.
+         *
+         * Example:
+         * <pre>
+         *   [{col:1, pattern: '#,###%', fractionDigits: 2 }, {col: 2, prefix: '$', groupingSymbol: ','}]
+         * </pre>
+         *
+         * @attribute numberFormats
+         * @type array
+         */
+        numberFormats: [],
 
         chartTypes: null,
 
@@ -369,9 +388,37 @@ Data can be provided in one of three ways:
             } else if (data.length > 0) {
               dataTable = google.visualization.arrayToDataTable(data);
             }
+
+          }
+
+          // Apply number formats to designated columns in dataTable
+          if (this.numberFormats && this.numberFormats.length){
+            this.applyNumberFormats(dataTable);
           }
 
           return dataTable;
+        },
+
+        applyNumberFormats: function(dataTable){
+          for (var i=0; i < this.numberFormats.length; i++){
+            var format = this.numberFormats[i];
+            
+            // If valid column is given, create formatter object and apply to column in dataTable
+            if (format.col && format.col < dataTable.If.length ){
+              var formatter = new google.visualization.NumberFormat({
+                decimalSymbol: format.decimalSymbol, 
+                fractionDigits: format.fractionDigits, 
+                groupingSymbol: format.groupingSymbol, 
+                negativeColor: format.negativeColor, 
+                negativeParens: format.negativeParens, 
+                pattern: format.pattern,  
+                prefix: format.prefix, 
+                suffix: format.suffix
+              });
+
+              formatter.format(dataTable, format.col);  
+            }
+          }
         }
       });
     })();

--- a/google-chart.html
+++ b/google-chart.html
@@ -195,7 +195,7 @@ Data can be provided in one of three ways:
          * @attribute numberFormats
          * @type array
          */
-        numberFormats: [],
+        numberFormats: null,
 
         chartTypes: null,
 
@@ -216,6 +216,7 @@ Data can be provided in one of three ways:
           this.options = {};
           this.rows = [];
           this.dataTable = null;
+          this.numberFormats = [];
         },
 
         readyForAction: function(e, detail, sender) {

--- a/google-chart.html
+++ b/google-chart.html
@@ -404,7 +404,7 @@ Data can be provided in one of three ways:
             var format = this.numberFormats[i];
             
             // If valid column is given, create formatter object and apply to column in dataTable
-            if (format.col && format.col < dataTable.If.length ){
+            if (format.col && format.col < dataTable.getNumberOfColumns()){
               var formatter = new google.visualization.NumberFormat({
                 decimalSymbol: format.decimalSymbol, 
                 fractionDigits: format.fractionDigits, 

--- a/google-chart.html
+++ b/google-chart.html
@@ -88,12 +88,11 @@ Data can be provided in one of three ways:
          * Sets the options for the chart.
          *
          * Example:
-         * <pre>{
-         *   title: "Chart title goes here",
-         *   hAxis: {title: "Categories"},
-         *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
-         *   legend: "none"
-         * };</pre>
+         *     {title: "Chart title goes here",
+         *      hAxis: {title: "Categories"},
+         *      vAxis: {title: "Values", minValue: 0, maxValue: 2},
+         *      legend: "none"}
+         *     
          * See [Google Visualization API reference (Chart Gallery)](https://google-developers.appspot.com/chart/interactive/docs/gallery)
          * for the options available to each chart type.
          *
@@ -109,8 +108,8 @@ Data can be provided in one of three ways:
          * not specify `data`.
          *
          * Example:
-         * <pre>[{label: "Categories", type: "string"},
-         *  {label: "Value", type: "number"}]</pre>
+         *     [{label: "Categories", type: "string"},
+         *      {label: "Value", type: "number"}]
          * See [Google Visualization API reference (addColumn)](https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn)
          * for column definition format.
          *
@@ -126,8 +125,8 @@ Data can be provided in one of three ways:
          * not specify `data`.
          *
          * Example:
-         * <pre>[["Category 1", 1.0],
-         *  ["Category 2", 1.1]]</pre>
+         *    [["Category 1", 1.0],
+         *    ["Category 2", 1.1]]
          * See [Google Visualization API reference (addRow)](https://google-developers.appspot.com/chart/interactive/docs/reference#addrow)
          * for row format.
          *
@@ -149,9 +148,9 @@ Data can be provided in one of three ways:
          * When specifying data with `data` you must not specify `cols` or `rows`.
          *
          * Example:
-         * <pre>[["Categories", "Value"],
-         *  ["Category 1", 1.0],
-         *  ["Category 2", 1.1]]</pre>
+         *    [["Categories", "Value"],
+         *    ["Category 1", 1.0],
+         *    ["Category 2", 1.1]]
          *
          * @attribute data
          * @type array, object, or string
@@ -169,9 +168,7 @@ Data can be provided in one of three ways:
          * to select a whole row, set column to null.
          *
          * Example:
-         * <pre>
          *     [{row:0,column:1}, {row:1, column:null}]
-         * </pre>
          *
          * @attribute selection
          * @type array
@@ -183,14 +180,13 @@ Data can be provided in one of three ways:
          *
          * An array of objects, each with:
          *     - a required `col` property (zero-based column number to which formatting applies)
-         *     - optional NumberFormat properties (`decimalSymbol`, `fractionDigits`, `groupingSymbol`, `negativeColor`, `negativeParens`, `pattern`, `prefix`, `suffix`)
+         *     - optional NumberFormat properties (`decimalSymbol`, `fractionDigits`, `groupingSymbol`, `negativeColor`, 
+         *     `negativeParens`, `pattern`, `prefix`, `suffix`)
          * 
          * See [Google Visualization API reference (NumberFormat)](https://developers.google.com/chart/interactive/docs/reference#numberformatter) for details.
          *
          * Example:
-         * <pre>
          *     [{col:1, pattern: '#,###%', fractionDigits: 2 }, {col: 2, prefix: '$', groupingSymbol: ','}]
-         * </pre>
          *
          * @attribute numberFormats
          * @type array
@@ -401,7 +397,7 @@ Data can be provided in one of three ways:
         },
 
         applyNumberFormats: function(dataTable){
-          for (var i = 0; i < this.numberFormats.length; i++){
+          for (var i = 0; i < this.numberFormats.length; i++) {
             var format = this.numberFormats[i];
             
             // If valid column is given, create formatter object and apply to column in dataTable

--- a/google-chart.html
+++ b/google-chart.html
@@ -77,7 +77,7 @@ Data can be provided in one of three ways:
          * - `area`, `bar`, `bubble`, `candlestick`, `column`, `combo`, `geo`,
          *   `histogram`, `line`, `pie`, `scatter`, `stepped-area`
          *
-         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a> for details.
+         * See [Google Visualization API reference (Chart Gallery)](https://google-developers.appspot.com/chart/interactive/docs/gallery) for details.
          *
          * @attribute type
          * @type string
@@ -94,7 +94,7 @@ Data can be provided in one of three ways:
          *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
          *   legend: "none"
          * };</pre>
-         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
+         * See [Google Visualization API reference (Chart Gallery)](https://google-developers.appspot.com/chart/interactive/docs/gallery)
          * for the options available to each chart type.
          *
          * @attribute options
@@ -111,7 +111,7 @@ Data can be provided in one of three ways:
          * Example:
          * <pre>[{label: "Categories", type: "string"},
          *  {label: "Value", type: "number"}]</pre>
-         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
+         * See [Google Visualization API reference (addColumn)](https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn)
          * for column definition format.
          *
          * @attribute cols
@@ -128,7 +128,7 @@ Data can be provided in one of three ways:
          * Example:
          * <pre>[["Category 1", 1.0],
          *  ["Category 2", 1.1]]</pre>
-         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
+         * See [Google Visualization API reference (addRow)](https://google-developers.appspot.com/chart/interactive/docs/reference#addrow)
          * for row format.
          *
          * @attribute rows
@@ -143,7 +143,7 @@ Data can be provided in one of three ways:
          *
          * The data format can be a two-dimensional array or the DataTable format
          * expected by Google Charts.
-         * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
+         * See [Google Visualization API reference (DataTable constructor)](https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable)
          * for data table format details.
          *
          * When specifying data with `data` you must not specify `cols` or `rows`.
@@ -170,7 +170,7 @@ Data can be provided in one of three ways:
          *
          * Example:
          * <pre>
-         *   [{row:0,column:1}, {row:1, column:null}]
+         *     [{row:0,column:1}, {row:1, column:null}]
          * </pre>
          *
          * @attribute selection
@@ -182,14 +182,14 @@ Data can be provided in one of three ways:
          * Sets the format for numbers shown in the tooltip.
          *
          * An array of objects, each with:
-         *   - a required `col` property (zero-based column number to which formatting applies)
-         *   - optional NumberFormat properties (`decimalSymbol`, `fractionDigits`, `groupingSymbol`, `negativeColor`, `negativeParens`, `pattern`, `prefix`, `suffix`)
+         *     - a required `col` property (zero-based column number to which formatting applies)
+         *     - optional NumberFormat properties (`decimalSymbol`, `fractionDigits`, `groupingSymbol`, `negativeColor`, `negativeParens`, `pattern`, `prefix`, `suffix`)
          * 
-         * See <a href="https://developers.google.com/chart/interactive/docs/reference#numberformatter">Google Visualization API reference (NumberFormat)</a> for details.
+         * See [Google Visualization API reference (NumberFormat)](https://developers.google.com/chart/interactive/docs/reference#numberformatter) for details.
          *
          * Example:
          * <pre>
-         *   [{col:1, pattern: '#,###%', fractionDigits: 2 }, {col: 2, prefix: '$', groupingSymbol: ','}]
+         *     [{col:1, pattern: '#,###%', fractionDigits: 2 }, {col: 2, prefix: '$', groupingSymbol: ','}]
          * </pre>
          *
          * @attribute numberFormats
@@ -400,7 +400,7 @@ Data can be provided in one of three ways:
         },
 
         applyNumberFormats: function(dataTable){
-          for (var i=0; i < this.numberFormats.length; i++){
+          for (var i = 0; i < this.numberFormats.length; i++){
             var format = this.numberFormats[i];
             
             // If valid column is given, create formatter object and apply to column in dataTable

--- a/google-chart.html
+++ b/google-chart.html
@@ -88,10 +88,12 @@ Data can be provided in one of three ways:
          * Sets the options for the chart.
          *
          * Example:
-         *     {title: "Chart title goes here",
-         *      hAxis: {title: "Categories"},
-         *      vAxis: {title: "Values", minValue: 0, maxValue: 2},
-         *      legend: "none"}
+         *     {
+         *       title: "Chart title goes here",
+         *       hAxis: {title: "Categories"},
+         *       vAxis: {title: "Values", minValue: 0, maxValue: 2},
+         *       legend: "none"
+         *     }
          *     
          * See [Google Visualization API reference (Chart Gallery)](https://google-developers.appspot.com/chart/interactive/docs/gallery)
          * for the options available to each chart type.


### PR DESCRIPTION
Currently, there's no way to apply formats to numbers shown in tooltips on the chart (only for the axes numbers). I exposed a new numberFormats attribute for this. Alternatively, we could include this in the options attribute if that is cleaner. 