### PR TITLE
added support for Printing PNG Charts (getImageURI())

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -262,6 +262,7 @@
   <p>Here's a line chart:</p>
 
   <google-chart
+    id='line_chart'
     type='line'
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
@@ -388,6 +389,22 @@
              ["Congo", "Africa", 10],
              ["Zaire", "Africa", 8]]'>
   </google-chart>
+
+  <p>Here's an image of the line chart:</p>
+
+  <div id='line_chart_div'></div>
+
+    <script>
+    document.addEventListener('WebComponentsReady', function() {
+      var chart_div = document.querySelector('#line_chart_div');
+      var chart = document.querySelector('#line_chart');
+
+      chart.addEventListener('google-chart-render', function() {
+        chart_div.innerHTML = '<img src="' + chart.getImageURI() + '">';
+      });
+
+    });
+  </script>
   
 </body>
 </html>

--- a/google-chart.html
+++ b/google-chart.html
@@ -282,6 +282,18 @@ Data can be provided in one of three ways:
       return null;
     },
 
+    /**
+     * Returns the chart serialized as an image URI.
+     *
+     * Call this after the chart is drawn (google-chart-render event).
+     *
+     * @method getImageURI
+     * @return {string} Returns image URI.
+     */
+    getImageURI: function() {
+      return this._chartObject.getImageURI();
+    },
+
     _loadChartTypes: function() {
       this._chartTypes = {
         'area': google.visualization.AreaChart,

--- a/google-chart.html
+++ b/google-chart.html
@@ -287,7 +287,6 @@ Data can be provided in one of three ways:
      *
      * Call this after the chart is drawn (google-chart-render event).
      *
-     * @method getImageURI
      * @return {string} Returns image URI.
      */
     getImageURI: function() {

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -75,6 +75,12 @@
         assert.isDefined(chart.rows[0][1]);
         assert.equal(chart.rows[0][1], 1);
       });
+      test('creates png chart uri', function () {
+        chart.drawChart();
+        var uri = chart.getImageURI();
+        assert.isString(uri);
+        assert.match(uri, /^data:image\/png;base64/, 'png regexp matches');
+      });
     });
   </script>
 


### PR DESCRIPTION
I added the support for `getImageURI()` ([Printing PNG Charts](https://developers.google.com/chart/interactive/docs/printing)).