### PR TITLE
Added materialDesign attribute to enable new charts.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -184,6 +184,17 @@
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
   </google-chart>
 
+  <p>Here's a Material Design bar chart:</p>
+
+  <google-chart
+    type='bar'
+    options='{"title": "Days in a month"}'
+    data='[
+      [{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}],
+      ["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'
+    material-design>
+  </google-chart>
+
   <p>Here's a bubble chart:</p>
 
   <google-chart
@@ -222,6 +233,16 @@
     options='{"title": "Days in a month"}'
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
+  </google-chart>
+
+  <p>Here's a Material Design column chart:</p>
+
+  <google-chart
+    type='column'
+    options='{"title": "Days in a month"}'
+    cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
+    rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'
+    material-design>
   </google-chart>
 
   <p>Here's a combo chart:</p>
@@ -269,6 +290,16 @@
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
   </google-chart>
 
+  <p>Here's a Material Design line chart:</p>
+
+  <google-chart
+    type='line'
+    options='{"title": "Days in a month"}'
+    cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
+    rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'
+    material-design>
+  </google-chart>
+
   <p>Here's a pie chart:</p>
 
   <google-chart
@@ -289,6 +320,20 @@
            [50, 80],
            [77, 50],
            [68, 15]]'>
+  </google-chart>
+
+  <p>Here's a Material Design scatter chart:</p>
+
+  <google-chart
+    type='scatter'
+    options='{"legend": "none"}'
+    data='[["A", "B"],
+           [20, 45],
+           [31, 66],
+           [50, 80],
+           [77, 50],
+           [68, 15]]'
+    material-design>
   </google-chart>
 
   <p>Here's a stepped area chart:</p>
@@ -405,6 +450,6 @@
 
     });
   </script>
-  
+
 </body>
 </html>

--- a/google-chart.html
+++ b/google-chart.html
@@ -171,6 +171,26 @@ Data can be provided in one of three ways:
       },
 
       /**
+       * Try to use the Material Design version of the chart.
+       *
+       * Material Design Charts are avaliable in BETA for the following types:
+       *  - <a href="https://developers.google.com/chart/interactive/docs/gallery/barchart#Material">Bar</a>
+       *  - <a href="https://developers.google.com/chart/interactive/docs/gallery/columnchart#Material">Column</a>
+       *  - <a href="https://developers.google.com/chart/interactive/docs/gallery/linechart#Material">Line</a>
+       *  - <a href="https://developers.google.com/chart/interactive/docs/gallery/scatterchart#Material">Scatter</a>
+       *
+       * @attribute materialDesign
+       * @type boolean
+       * @default false
+       *
+       */
+      materialDesign: {
+        type: Boolean,
+        value: false,
+        observer: '_materialDesignChanged'
+      },
+
+      /**
        * Selected datapoint(s) in the map.
        *
        * An array of objects, each with a numeric row and/or column property.
@@ -236,6 +256,15 @@ Data can be provided in one of three ways:
       }
     },
 
+    _materialDesignChanged: function() {
+      if(this.$$('google-legacy-loader').libraryLoaded) {
+        this._isReady = false;
+        this._canDraw = false;
+        this._chartObject = null;
+        this._readyForAction();
+      }
+    },
+
     /**
      * Draws the chart.
      *
@@ -269,10 +298,19 @@ Data can be provided in one of three ways:
                       { selection: this._chartObject.getSelection() });
               }.bind(this));
 
+          if (this.materialDesign) {
+            if (this.type == 'bar') {
+              this.options.bars = 'horizontal';
+              this.options = google.charts.Bar.convertOptions(this.options);
+            } else if (this.type == 'column') {
+              this.options.bars = 'vertical';
+              this.options = google.charts.Bar.convertOptions(this.options);
+            }
+          }
 
           this._chartObject.draw(this._dataTable, this.options);
 
-          if (this._chartObject.setSelection){
+          if (this._chartObject.setSelection) {
             this._chartObject.setSelection(this.selection);
           }
         } else {
@@ -296,41 +334,57 @@ Data can be provided in one of three ways:
     _loadChartTypes: function() {
       this._chartTypes = {
         'area': google.visualization.AreaChart,
-        'bar': google.visualization.BarChart,
         'bubble': google.visualization.BubbleChart,
         'candlestick': google.visualization.CandlestickChart,
-        'column': google.visualization.ColumnChart,
         'combo': google.visualization.ComboChart,
         'geo': google.visualization.GeoChart,
         'histogram': google.visualization.Histogram,
-        'line': google.visualization.LineChart,
         'pie': google.visualization.PieChart,
-        'scatter': google.visualization.ScatterChart,
         'stepped-area': google.visualization.SteppedAreaChart,
         'table': google.visualization.Table,
         'gauge': google.visualization.Gauge,
         'treemap': google.visualization.TreeMap
       };
+
+      if (this.materialDesign) {
+        this._chartTypes['bar'] = google.charts.Bar;
+        this._chartTypes['column'] = google.charts.Bar;
+        this._chartTypes['line'] = google.charts.Line;
+        this._chartTypes['scatter'] = google.charts.Scatter;
+      } else{
+        this._chartTypes['bar'] = google.visualization.BarChart;
+        this._chartTypes['column'] = google.visualization.ColumnChart;
+        this._chartTypes['line'] = google.visualization.LineChart;
+        this._chartTypes['scatter'] = google.visualization.ScatterChart;
+      }
     },
 
     _loadPackageByChartType: function() {
       this._packages = {
         'area': 'corechart',
-        'bar': 'corechart',
         'bubble': 'corechart',
         'candlestick': 'corechart',
-        'column': 'corechart',
         'combo': 'corechart',
         'geo': 'corechart',
         'histogram': 'corechart',
-        'line': 'corechart',
         'pie': 'corechart',
-        'scatter': 'corechart',
         'stepped-area': 'corechart',
         'table': 'table',
         'gauge': 'gauge',
         'treemap': 'treemap'
       };
+
+      if (this.materialDesign) {
+        this._packages['bar'] = 'bar';
+        this._packages['column'] = 'bar';
+        this._packages['line'] = 'line';
+        this._packages['scatter'] = 'scatter';
+      } else{
+        this._packages['bar'] = 'corechart';
+        this._packages['column'] = 'corechart';
+        this._packages['line'] = 'corechart';
+        this._packages['scatter'] = 'corechart';
+      }
     },
 
     _loadData: function() {


### PR DESCRIPTION
#30 implementation for the charts that have a Material Design Beta version. (This is an updated #39 PR.)

All original charts work fine. 

The new  `material-design` charts on the demo page sometime have an issue rendering. This can be resolved by `chart._chartObject = null && chart.drawChart()`. I believe it's an issue with the timing of the loading, but since the code is obfuscated there's nothing a community contribution can do.

Anecdotally, using just a couple `material-design` charts on a single page of an SPA renders correctly every time. (#ItWorksOnMyMachine)

Given that these are marked as BETA, it would be great if people could opt-in to using the feature and the known hiccups until someone with access to the source can diagnose the root cause of the issue.
