### PR TITLE
Bugfix: Craete new instance of iron-request

### DIFF
--- a/google-chart.html
+++ b/google-chart.html
@@ -50,7 +50,6 @@ Data can be provided in one of three ways:
 <dom-module id="google-chart">
   <link rel="import" type="css" href="google-chart.css">
   <template>
-    <iron-request id="xhr"></iron-request>
     <div id="chartdiv"></div>
   </template>
 </dom-module>
@@ -456,7 +455,8 @@ Data can be provided in one of three ways:
       var dataTable;
       if (typeof data == 'string' || data instanceof String) {
         // Load data asynchronously, from external URL.
-        dataTable = this.$.xhr.send({url: data, handleAs: 'json'})
+        var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
+        dataTable = request.send({url: data, handleAs: 'json'})
             .then(function(xhr) {
               return xhr.response;
             });

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -172,6 +172,10 @@ suite('<google-chart>', function() {
         });
       });
     });
+    test('multiple calls to JSON URL', function(done) {
+      setDataAndWaitForRender('test-data-array.json', done);
+      setDataAndWaitForRender('test-data-object.json', done);
+    });
   });
 });
 </script>


### PR DESCRIPTION
iron-request instances can not be re-used.
This fix removes iron-request from the template and dynamically creates
a new instance for each request.
This fixes #105 