### PR TITLE
Should load the Google Charts library using the latest API.

### DIFF
--- a/charts-loader.html
+++ b/charts-loader.html
@@ -1,4 +1,4 @@
 <!--
 `charts-loader` provides access to the Google Charts loading API.
 -->
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script src="https://www.gstatic.com/charts/loader.js"></script>

--- a/charts-loader.html
+++ b/charts-loader.html
@@ -1,0 +1,4 @@
+<!--
+`charts-loader` provides access to the Google Charts loading API.
+-->
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>

--- a/google-chart.html
+++ b/google-chart.html
@@ -132,7 +132,7 @@ Data can be provided in one of three ways:
     var pkg = opt_pkg || DEFACTO_CHART_PACKAGE;
     if (pkgPromises[pkg]) return pkgPromises[pkg];
     pkgPromises[pkg] = new Promise(function(resolve) {
-      google.charts.load('current', {packages: ['corechart']});
+      google.charts.load('current', {packages: [pkg]});
       google.charts.setOnLoadCallback(function() {
         resolve(google.visualization);
       });

--- a/google-chart.html
+++ b/google-chart.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-request.html">
 <link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
-<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 
 <!--
 `google-chart` encapsulates Google Charts as a web component, allowing you to easily visualize
@@ -132,11 +132,9 @@ Data can be provided in one of three ways:
     var pkg = opt_pkg || DEFACTO_CHART_PACKAGE;
     if (pkgPromises[pkg]) return pkgPromises[pkg];
     pkgPromises[pkg] = new Promise(function(resolve) {
-      google.load('visualization', '1', {
-        packages: [pkg],
-        callback: function() {
-          resolve(google.visualization);
-        }
+      google.charts.load('current', {packages: ['corechart']});
+      google.charts.setOnLoadCallback(function() {
+        resolve(google.visualization);
       });
     });
     return pkgPromises[pkg];

--- a/google-chart.html
+++ b/google-chart.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-request.html">
 <link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<link rel="import" href="charts-loader.html">
 
 <!--
 `google-chart` encapsulates Google Charts as a web component, allowing you to easily visualize


### PR DESCRIPTION
The Google Charts documentation recommends using this approach:
https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code

This fixes an issue where the Google Charts library had released a version with a bug affecting datetime x-values. The fix was released and became available using the updated loading API, however, the older, depcrecated API continued loading the broken version.

This update will load the current stable version of the Google Charts library.

Fixes #112