### PR TITLE
feat(a11y): allow to show alternative content with the chart

### DIFF
--- a/google-chart.html
+++ b/google-chart.html
@@ -52,6 +52,7 @@ Data can be provided in one of three ways:
   <template>
     <iron-request id="xhr"></iron-request>
     <div id="chartdiv"></div>
+    <content></content>
   </template>
 </dom-module>
 

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -20,7 +20,9 @@
 
 <test-fixture id="chart-fixture">
   <template>
-    <google-chart></google-chart>
+    <google-chart>
+      <p>Some alternative</p>
+    </google-chart>
   </template>
 </test-fixture>
 
@@ -42,6 +44,9 @@ suite('<google-chart>', function() {
   suite('Default Functionality', function() {
     setup(function() {
       chart.data = [ ['Data', 'Value'], ['Something', 1] ];
+    });
+    test('render alternative content', function() {
+      assert.equal(chart.querySelectorAll('p').length, 1);
     });
     test('fires google-chart-render event for initial load', function(done) {
       chart.addEventListener('google-chart-render', function() {


### PR DESCRIPTION
Hi, I propose this change, to allow the user to add some alternative content with the chart. This way, the user can access to some information about the chart. 

I think that a more complete feature would be that with the data you configure the component, it renders a table. For example, if you choose a pie, below the pie the component will generate a table with the information in the chart. 

Regards.