### PR TITLE
Add unit test proving multiple chart instances can load.

### DIFF
--- a/google-chart.html
+++ b/google-chart.html
@@ -132,7 +132,7 @@ Data can be provided in one of three ways:
     var pkg = opt_pkg || DEFACTO_CHART_PACKAGE;
     if (pkgPromises[pkg]) return pkgPromises[pkg];
     pkgPromises[pkg] = new Promise(function(resolve) {
-      google.charts.load('44', {packages: [pkg]});
+      google.charts.load('current', {packages: [pkg]});
       google.charts.setOnLoadCallback(function() {
         resolve(google.visualization);
       });

--- a/google-chart.html
+++ b/google-chart.html
@@ -132,7 +132,7 @@ Data can be provided in one of three ways:
     var pkg = opt_pkg || DEFACTO_CHART_PACKAGE;
     if (pkgPromises[pkg]) return pkgPromises[pkg];
     pkgPromises[pkg] = new Promise(function(resolve) {
-      google.charts.load('current', {packages: [pkg]});
+      google.charts.load('44', {packages: [pkg]});
       google.charts.setOnLoadCallback(function() {
         resolve(google.visualization);
       });

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -101,6 +101,18 @@ suite('<google-chart>', function() {
         done();
       });
     });
+    test('can render multiple instances', function (done) {
+      var secondChart = document.createElement('google-chart');
+      secondChart.data = [ ['Data', 'Value'], ['Something', 1] ];
+
+      // Ensure second chart is rendered. Clean up test.
+      secondChart.addEventListener('google-chart-render', function() {
+        document.body.removeChild(secondChart);
+        done();
+      });
+
+      document.body.appendChild(secondChart);
+    });
   });
 
   suite('Data Source Types', function() {


### PR DESCRIPTION
Please take a look at this test; I was not able to get the test to fail by changing the Google Charts library version to 44 or 45. I believe this test should fail if we become unable to load multiple google-chart instances, but again, I wasn't able to get this test to fail.