### PR TITLE
Add support for organization charts. Fixes #132

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -281,6 +281,22 @@
     cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
     rows='[["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30]]'>
   </google-chart>
+  
+  <p>Here's a organization chart:</p>
+  
+  <google-chart
+    id="org-chart",
+    type="org",
+    options='{"allowHtml": "true"}'
+    cols='[{"label": "Name", "type": "string"},{"label":"Manager", "type":"string"},{"label":"ToolTip", "type":"string"}]'
+    rows='[[{"v":"Mike", "f":"Mike<div style=\"color:red; font-style:italic\">President</div>"},
+            "", "The President"],
+            [{"v":"Jim", "f":"Jim<div style=\"color:red; font-style:italic\">Vice President</div>"},
+            "Mike", "VP"],
+            ["Alice", "Mike", ""],
+            ["Bob", "Jim", "Bob Sponge"],
+            ["Carol", "Bob", ""]]'>
+  </google-chart>
 
   <p>Here's a pie chart:</p>
 

--- a/google-chart-loader.html
+++ b/google-chart-loader.html
@@ -46,6 +46,10 @@
     'line': {
       ctor: 'LineChart',
     },
+    'org': {
+      ctor: 'OrgChart',
+      pkg: 'orgchart',
+    },
     'pie': {
       ctor: 'PieChart',
     },


### PR DESCRIPTION
This commit adds support for organization charts, as well as example use in demos. It's small, because you guys made it so easy!

I didn't found any information about what contributions are admitted, so I thought I will just drop a PR.