### PR TITLE
Add Event listening and deep Option change support.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -142,6 +142,49 @@
     }());
   </script>
 
+  <p>Here's a pie chart listening for `onmouseover`:</p>
+
+  <style>
+    #mouseover-demo {
+      position: relative;
+      height: 300px;
+    }
+
+    #mouseover-chart {
+      float: left;
+    }
+
+    #mouseover-display {
+      display: inline-block;
+      position: relative;
+      top: 50%;
+    }
+  </style>
+  <div id="mouseover-demo">
+    <google-chart
+      id="mouseover-chart"
+      type="pie"
+      options='{"title": "Distribution of days in 2001H1"}'
+      cols='[{"label": "Month", "type": "string"},{"label": "Days", "type": "number"}]'
+      rows='[ ["Jan", 31],["Feb", 28],["Mar", 31],["Apr", 30],["May", 31],["Jun", 30] ]'
+      events='["onmouseover"]'>
+    </google-chart>
+    <div id="mouseover-display">
+      Moused over row: <span id="mouseover-label">None</span>.
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var chart = document.getElementById('mouseover-chart');
+      var label = document.getElementById('mouseover-label');
+
+      chart.addEventListener('google-chart-onmouseover', function(e) {
+        label.textContent = e.detail.data.row;
+      });
+    }());
+  </script>
+
   <p>Here's a chart defined using <code>data</code>, rather than <code>rows</code> and <code>cols</code>:</p>
 
   <google-chart

--- a/google-chart.html
+++ b/google-chart.html
@@ -131,12 +131,16 @@ Data can be provided in one of three ways:
        * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
        * for the options available to each chart type.
        *
+       * This property is observed via a deep object observer.
+       * If you would like to make changes to a sub-property, be sure to use the
+       * Polymer method `set`: `googleChart.set('options.vAxis.logScale', true)`
+       * (Note: Missing parent properties are not automatically created.)
+       *
        * @attribute options
        * @type {!Object|undefined}
        */
       options: {
-        type: Object,
-        observer: 'redraw'
+        type: Object
       },
 
       /**
@@ -260,7 +264,10 @@ Data can be provided in one of three ways:
       },
     },
 
-    observers: ['_draw(_chart, _dataView)'],
+    observers: [
+      '_draw(_chart, _dataView)',
+      '_subOptionChanged(options.*)'
+    ],
 
     listeners: {
       'google-chart-select': '_updateSelection',
@@ -291,6 +298,14 @@ Data can be provided in one of three ways:
             this._setDrawn(false);
             this._chart = chart;
           }.bind(this));
+    },
+
+    _subOptionChanged: function(optionChangeDetails) {
+      this.options = optionChangeDetails.base;
+      // Debounce to allow for multiple option changes in one redraw
+      this.debounce('optionChangeRedraw', function() {
+        this.redraw();
+      }, 5);
     },
 
     _setSelection: function() {

--- a/google-chart.html
+++ b/google-chart.html
@@ -101,6 +101,24 @@ Data can be provided in one of three ways:
       },
 
       /**
+       * Enumerates the chart events that should be fired.
+       *
+       * Charts support a variety of events. By default, this element only
+       * fires on `ready` and `select`. If you would like to be notified of
+       * other chart events, use this property to list them.
+       * Events `ready` and `select` are always fired.
+       * Changes to this property are _not_ observed. Events are attached only
+       * at chart construction time.
+       *
+       * @attribute events
+       * @type !Array
+       */
+      events: {
+        type: Array,
+        value: function() { return []; }
+      },
+
+      /**
        * Sets the options for the chart.
        *
        * Example:
@@ -261,8 +279,15 @@ Data can be provided in one of three ways:
     _typeChanged: function() {
       this.$.loader.create(this.type, this.$.chartdiv)
           .then(function(chart) {
-            this.$.loader.fireOnChartEvent(chart, 'select');
-            this.$.loader.fireOnChartEvent(chart, 'ready');
+            var loader = this.$.loader;
+            Object.keys(this.events.concat(['select', 'ready'])
+                .reduce(function(set, eventName) {
+                  set[eventName] = true;
+                  return set;
+                }, {}))
+                .forEach(function(eventName) {
+                  loader.fireOnChartEvent(chart, eventName);
+                });
             this._setDrawn(false);
             this._chart = chart;
           }.bind(this));

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -117,6 +117,25 @@ suite('<google-chart>', function() {
     });
   });
 
+  suite('Events', function() {
+    setup(function() {
+      chart.data = [ ['Data', 'Value'], ['Something', 1] ];
+    });
+
+    test('can be added', function(done) {
+      chart.events = ['onmouseover'];
+      chart.addEventListener('google-chart-ready', function() {
+        google.visualization.events.trigger(
+            chart._chart, 'onmouseover', {'row': 1, 'column': 5});
+      });
+      chart.addEventListener('google-chart-onmouseover', function(e) {
+        assert.equal(e.detail.data.row, 1);
+        assert.equal(e.detail.data.column, 5);
+        done();
+      });
+    });
+  });
+
   suite('Data Source Types', function() {
     test('[rows] and [cols]', function (done) {
       chart.cols = [

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -95,6 +95,25 @@ suite('<google-chart>', function() {
         }
       });
     });
+    test('can change deep options', function(done) {
+      chart.options = {'title': 'Old Title'};
+      var spyRedraw = sinon.spy(chart, 'redraw');
+      var expectedTitle = 'New Title';
+      var initialDraw = true;
+      chart.addEventListener('google-chart-ready', function() {
+        if (initialDraw) {
+          initialDraw = false;
+          chart.set('options.title', 'Debounced Title');
+          chart.set('options.title', expectedTitle);
+          assert.isFalse(spyRedraw.called);
+        } else {
+          assert.equal(chart.$$('text').innerHTML, expectedTitle);
+          assert.isTrue(spyRedraw.calledOnce);
+          chart.redraw.restore();
+          done();
+        }
+      });
+    });
     test('creates png chart uri', function (done) {
       chart.addEventListener('google-chart-ready', function(event) {
         var uri = chart.imageURI;


### PR DESCRIPTION
- Enables the chart to fire any chart events.
- Allows the user to change options without calling `redraw()`.

To enable other events:
```html
<!-- Events: `select` and `ready` are *always* fired. -->
<google-chart events='["onmouseover", "rangechange"]'></google-chart>
```
```js
listeners: {
  'google-chart-onmouseover': '_onMouseOver',
  'google-chart-rangechange': '_onRangeChange'
},
// or:
this.listen(googleChart, 'google-chart-onmouseover', '_onMouseOver');
this.listen(googleChart, 'google-chart-rangechange', '_onRangeChange');
// ...
_onMouseOver: function(e) {
  console.log('Moused over', e.detail.data.row, e.detail.data.column);
},
_onRangeChange: function(e) {
  console.log('Range changed', e.detail.data.start, e.detail.data.end);
}
```

To update options without calling `redraw()`:
```html
<google-chart options='{"vAxis": {"logScale": true}}'></google-chart>
```
```js
googleChart.set('options.vAxis.logScale', false);
```