### PR TITLE
Fix browser (IE) compatibility

### DIFF
--- a/google-chart-loader.html
+++ b/google-chart-loader.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
+<link rel="import" href="../promise-polyfill/promise-polyfill.html">
 <link rel="import" href="charts-loader.html">
 
 <script>
@@ -87,7 +87,7 @@
    * @return {!Object} the namespace that contains the chart's constructor
    */
   function namespaceForType(type) {
-    return google[type.startsWith('md-') ? 'charts' : 'visualization'];
+    return google[type.indexOf('md-') === 0 ? 'charts' : 'visualization'];
   }
 
   /** @type {!Object<string, boolean>} set-like object of gviz packages to load */


### PR DESCRIPTION
Fixed the following issues to make this component work in IE.

1.  `google-chart-loader` uses `Promise.all`which isn't part of the lite polyfill.
Changed the import accordingly.

2.  `String.prototype.startsWith` (ECMAScript 6) isn't implemented in IE yet.
Changed to `indexOf(...) === 0` (no need for a polyfill for this)
