### PR TITLE
Configurable language/locale

### DIFF
--- a/google-chart-loader.html
+++ b/google-chart-loader.html
@@ -162,7 +162,10 @@
           return;
         }
         packagesToLoad = {};
-        google.charts.load('current', {'packages': packages});
+        google.charts.load('current', {
+          'packages': packages,
+          'language': document.documentElement.lang || 'en'
+        });
         google.charts.setOnLoadCallback(function() {
           packages.forEach(function(pkg) {
             this.fire('loaded', pkg);

--- a/google-chart.html
+++ b/google-chart.html
@@ -48,6 +48,12 @@ Data can be provided in one of three ways:
 - Via the `view` attribute, passing in a Google DataView object:
 
       view='{{dataView}}'
+
+You can display the charts in locales other than "en" by setting the `lang` attribute
+on the `html` tag of your document.
+
+    <html lang="ja">
+
 @demo
 -->
 <dom-module id="google-chart">


### PR DESCRIPTION
Fixes https://github.com/GoogleWebComponents/google-chart/issues/145

@wesalvaro Following our discussion I thought it would be best to also offer a way for people who want more control, to define the locale directly on the `google-chart-loader` element as well, defaulting to the implicit html lang or 'en'.