### PR TITLE
Add version property

### DIFF
--- a/google-chart-loader.html
+++ b/google-chart-loader.html
@@ -134,6 +134,16 @@
         type: String,
         observer: '_loadPackageForType',
       },
+      /**
+       * Version of the Google Visualization API to use.
+       *
+       * @attribute version
+       * @type {string}
+       */
+      version: {
+        type: String,
+        value: 'current'
+      }
     },
 
     /**
@@ -162,7 +172,7 @@
           return;
         }
         packagesToLoad = {};
-        google.charts.load('current', {
+        google.charts.load(this.version, {
           'packages': packages,
           'language': document.documentElement.lang || 'en'
         });

--- a/google-chart.html
+++ b/google-chart.html
@@ -59,7 +59,7 @@ on the `html` tag of your document.
 <dom-module id="google-chart">
   <link rel="import" type="css" href="google-chart.css">
   <template>
-    <google-chart-loader id="loader" type="[[type]]"></google-chart-loader>
+    <google-chart-loader id="loader" type="[[type]]" version="[[version]]"></google-chart-loader>
     <div id="chartdiv"></div>
   </template>
 </dom-module>
@@ -268,6 +268,17 @@ on the `html` tag of your document.
         readOnly: true,
         value: false
       },
+
+      /**
+       * Version of the Google Visualization API to use.
+       *
+       * @attribute version
+       * @type String  
+       */
+      version: {
+        type: String,
+        value: 'current'
+      }
     },
 
     observers: [


### PR DESCRIPTION
Add version property to google-chart and google-chart-loader.  Allows callers to specify a version of the google visualization API to use.

The default is set to 'current' - which is what is currently used on google-chart.

Fixes #159 