### PR TITLE
from polymerlabs to PolymerLabs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "google-apis": "GoogleWebComponents/google-apis#^1.0.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0"
+    "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.2",


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerLabs" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.