### PR TITLE
Migrate to ChartWrapper

### DIFF
--- a/google-chart-loader.js
+++ b/google-chart-loader.js
@@ -452,9 +452,9 @@ export async function dataTable(data) {
     return google.visualization.arrayToDataTable(data);
   } else if (data.length === 0) {
     // Chart data was empty.
-    // We return null instead of creating an empty DataTable because most
+    // We throw instead of creating an empty DataTable because most
     // (if not all) charts will render a sticky error in this situation.
-    return Promise.reject('Data was empty.');
+    throw new Error('Data was empty.');
   }
-  return Promise.reject('Data format was not recognized.');
+  throw new Error('Data format was not recognized.');
 }

--- a/google-chart.js
+++ b/google-chart.js
@@ -459,8 +459,8 @@ Polymer({
       const dt = await dataTable({cols});
       dt.addRows(rows);
       this._data = dt;
-    } catch (e) {
-      this.$.chartdiv.textContent = e.message;
+    } catch (reason) {
+      this.$.chartdiv.textContent = reason;
     }
   },
 

--- a/google-chart.js
+++ b/google-chart.js
@@ -459,8 +459,8 @@ Polymer({
       const dt = await dataTable({cols});
       dt.addRows(rows);
       this._data = dt;
-    } catch (reason) {
-      this.$.chartdiv.textContent = reason;
+    } catch (e) {
+      this.$.chartdiv.textContent = e.message;
     }
   },
 

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -97,11 +97,12 @@ suite('<google-chart>', function() {
     });
     test('can change deep options', function(done) {
       chart.options = {'title': 'Old Title'};
-      var spyRedraw = sinon.spy(chart, 'redraw');
+      var spyRedraw;
       var expectedTitle = 'New Title';
       var initialDraw = true;
       chart.addEventListener('google-chart-ready', function() {
         if (initialDraw) {
+          spyRedraw = sinon.spy(chart._chartWrapper, 'draw');
           initialDraw = false;
           chart.set('options.title', 'Debounced Title');
           chart.set('options.title', expectedTitle);
@@ -109,7 +110,7 @@ suite('<google-chart>', function() {
         } else {
           assert.equal(chart.$$('text').innerHTML, expectedTitle);
           assert.isTrue(spyRedraw.calledOnce);
-          chart.redraw.restore();
+          chart._chartWrapper.draw.restore();
           done();
         }
       });
@@ -145,7 +146,7 @@ suite('<google-chart>', function() {
       chart.events = ['onmouseover'];
       chart.addEventListener('google-chart-ready', function() {
         google.visualization.events.trigger(
-            chart._chart, 'onmouseover', {'row': 1, 'column': 5});
+            chart._chartWrapper.getChart(), 'onmouseover', {'row': 1, 'column': 5});
       });
       chart.addEventListener('google-chart-onmouseover', function(e) {
         assert.equal(e.detail.data.row, 1);


### PR DESCRIPTION
Replace `<google-chart-loader>` with `google.visualization.ChartWrapper`.
`ChartWrapper` provides similar functionality.

API of the component stays the same.

That PR makes `<google-chart-loader>` unused. It can be deprecated and removed once all code using it is migrated.
Migration to `ChartWrapper` was a part of #204 PR.