### PR TITLE
Fix: update selection after selection event

### DIFF
--- a/google-chart.js
+++ b/google-chart.js
@@ -364,6 +364,9 @@ Polymer({
       google.visualization.events.addListener(chartWrapper, 'ready', () => {
         this._setDrawn(true);
       });
+      google.visualization.events.addListener(chartWrapper, 'select', () => {
+        this.selection = chartWrapper.getChart().getSelection();
+      });
       this._propagateEvents(DEFAULT_EVENTS, chartWrapper);
     });
   },

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -79,6 +79,27 @@ suite('<google-chart>', function() {
         return chart.$$('rect[stroke="#ffffff"]');
       }, done);
     });
+    test('updates selection', function(done) {
+      chart.data = [
+        ['Data', 'Value'],
+        ['Something 1', 1],
+        ['Something 2', 2],
+        ['Something 3', 3],
+      ];
+      chart.addEventListener('google-chart-select', () => {
+        assert.sameDeepMembers(chart.selection, [ {row: 2, column: 1} ]);
+        done();
+      }, {once: true});
+      chart.selection = [ {row: 0, column: 1} ];
+      chart.addEventListener('google-chart-ready', () => {
+        // Look for something that can be clicked. Find rectangles for legend
+        // and each bar.
+        const rects = chart.$$('#chartdiv')
+            .querySelectorAll('rect[fill="#3366cc"]');
+        // Click on the last bar ('Something 3').
+        rects[3].dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      }, {once: true});
+    });
     test('default options are null', function() {
       assert.equal(chart.options, null);
     });


### PR DESCRIPTION
Update `selection` property after a selection event.

This fixes a regression introduced in #250 and adds a test to prevent similar issues in the future.