### PR TITLE
Workaround for slow initial ready event for tables

### DIFF
--- a/google-chart.js
+++ b/google-chart.js
@@ -128,6 +128,11 @@ Polymer({
       #chartdiv {
         width: 100%;
       }
+
+      /* Workaround for slow initial ready event for tables. */
+      .google-visualization-table-loadtest {
+        padding-left: 6px;
+      }
     </style>
     <div id="styles"></div>
     <div id="chartdiv"></div>


### PR DESCRIPTION
Workaround for slow initial ready event for tables: #252 

Google Charts table uses setTimeout loop to wait for CSS before firing
the initial ready event. We copy CSS into the shadow root after the
ready event, so we need to break the loop to avoid long delay.

See: Table.prototype.waitForCss_ in Google Charts.