### PR TITLE
Stop loading google-chart-loader from google-chart

### DIFF
--- a/google-chart-loader.js
+++ b/google-chart-loader.js
@@ -8,6 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
 */
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { load, dataTable } from './loader.js';
 
 /** @type {string} Most charts use this package. */
 var DEFACTO_CHART_PACKAGE = 'corechart';
@@ -116,78 +117,12 @@ function namespaceForType(type) {
   return google[type.indexOf('md-') === 0 ? Namespace.CHARTS : Namespace.VIS];
 }
 
-/**
- * Promise that resolves when the gviz loader script is loaded, which
- * provides access to the Google Charts loading API.
- * @type {!Promise}
- */
-var loaderPromise = new Promise(function(resolve, reject) {
-  // Resolve immediately if the loader script has been added already and
-  // `google.charts.load` is available. Adding the loader script twice throws
-  // an error.
-  if (typeof google !== 'undefined' && google.charts &&
-      typeof google.charts.load === 'function') {
-    resolve();
-  } else {
-    // Try to find existing loader script.
-    var loaderScript = document.querySelector(
-        'script[src="https://www.gstatic.com/charts/loader.js"]');
-    if (!loaderScript) {
-      // If the loader is not present, add it.
-      loaderScript =
-          /** @type {!HTMLScriptElement} */ (document.createElement('script'));
-      // Specify URL directly to pass JS compiler conformance checks.
-      loaderScript.src = 'https://www.gstatic.com/charts/loader.js';
-      document.head.appendChild(loaderScript);
-    }
-    loaderScript.addEventListener('load', resolve);
-    loaderScript.addEventListener('error', reject);
-  }
-});
 /** @type {!Object<string, boolean>} set-like object of gviz packages to load */
 var packagesToLoad = {};
 /** @type {!Object<string, !Promise>} promises for the various packages */
 var promises = {};
 /** @type {!Object<string, function(!Object)>} resolves for the package promises */
 var resolves = {};
-
-/**
- * @typedef {{
- *   version: (string|undefined),
- *   packages: (!Array<string>|undefined),
- *   language: (string|undefined),
- *   mapsApiKey: (string|undefined),
- * }}
- */
-var LoadSettings;
-
-/**
- * Loads Google Charts API with the selected settings or using defaults.
- *
- * The following settings are available:
- * - version: which version of library to load, default: 'current',
- * - packages: which chart packages to load, default: ['corechart'],
- * - language: what language to load library in, default: `lang` attribute on
- *   `<html>` or 'en' if not specified,
- * - mapsApiKey: key to use for maps API.
- *
- * @param {!LoadSettings=} settings
- * @return {!Promise}
- */
-export async function load(settings = {}) {
-  await loaderPromise;
-  const {
-    version = 'current',
-    packages = [DEFACTO_CHART_PACKAGE],
-    language = document.documentElement.lang || 'en',
-    mapsApiKey,
-  } = settings;
-  return google.charts.load(version, {
-    'packages': packages,
-    'language': language,
-    'mapsApiKey': mapsApiKey,
-  });
-}
 
 Polymer({
   is: 'google-chart-loader',
@@ -244,7 +179,7 @@ Polymer({
         return;
       }
       packagesToLoad = {};
-      loaderPromise.then(() => load({packages})).then(() => {
+      load({packages}).then(() => {
         packages.forEach((pkg) => {
           this.fire('loaded', pkg);
           resolves[pkg](google.visualization);
@@ -405,56 +340,3 @@ Polymer({
     });
   }
 });
-
-/**
- * Creates a DataTable object for use with a chart.
- *
- * Multiple different argument types are supported. This is because the
- * result of loading the JSON data URL is fed into this function for
- * DataTable construction and its format is unknown.
- *
- * The data argument can be one of a few options:
- *
- * - null/undefined: An empty DataTable is created. Columns must be added
- * - !DataTable: The object is simply returned
- * - {{cols: !Array, rows: !Array}}: A DataTable in object format
- * - {{cols: !Array}}: A DataTable in object format without rows
- * - !Array<!Array>: A DataTable in 2D array format
- *
- * Un-supported types:
- *
- * - Empty !Array<!Array>: (e.g. `[]`) While technically a valid data
- *   format, this is rejected as charts will not render empty DataTables.
- *   DataTables must at least have columns specified. An empty array is most
- *   likely due to a bug or bad data. If one wants an empty DataTable, pass
- *   no arguments.
- * - Anything else
- *
- * See <a href="https://developers.google.com/chart/interactive/docs/reference#datatable-class">the docs</a> for more details.
- *
- * @param {!Array|{cols: !Array, rows: (!Array<!Array>|undefined)}|undefined} data
- *     the data with which we should use to construct the new DataTable object
- * @return {!Promise<!google.visualization.DataTable>} promise for the created DataTable
- */
-export async function dataTable(data) {
-  // Ensure that `google.visualization` namespace is added to the document.
-  await load();
-  if (data == null) {
-    return new google.visualization.DataTable();
-  } else if (data.getNumberOfRows) {
-    // Data is already a DataTable
-    return /** @type {!google.visualization.DataTable} */ (data);
-  } else if (data.cols) {  // data.rows may also be specified
-    // Data is in the form of object DataTable structure
-    return new google.visualization.DataTable(data);
-  } else if (data.length > 0) {
-    // Data is in the form of a two dimensional array.
-    return google.visualization.arrayToDataTable(data);
-  } else if (data.length === 0) {
-    // Chart data was empty.
-    // We throw instead of creating an empty DataTable because most
-    // (if not all) charts will render a sticky error in this situation.
-    throw new Error('Data was empty.');
-  }
-  throw new Error('Data format was not recognized.');
-}

--- a/google-chart.js
+++ b/google-chart.js
@@ -11,7 +11,7 @@ import '@polymer/iron-ajax/iron-request.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
-import { dataTable, load } from './google-chart-loader.js';
+import { createChartWrapper, dataTable } from './loader.js';
 
 const DEFAULT_EVENTS = ['ready', 'select'];
 
@@ -551,14 +551,3 @@ Polymer({
     }
   }
 });
-
-/**
- * Creates new `ChartWrapper`.
- * @param {!Element} container Element in which the chart will be drawn
- * @return {!Promise<!google.visualization.ChartWrapper>}
- */
-async function createChartWrapper(container) {
-  // Ensure that `google.visualization` namespace is added to the document.
-  await load();
-  return new google.visualization.ChartWrapper({'container': container});
-}

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,140 @@
+/**
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at https://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at https://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at https://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
+*/
+
+/**
+ * Promise that resolves when the gviz loader script is loaded, which
+ * provides access to the Google Charts loading API.
+ * @type {!Promise}
+ */
+const loaderPromise = new Promise((resolve, reject) => {
+  // Resolve immediately if the loader script has been added already and
+  // `google.charts.load` is available. Adding the loader script twice throws
+  // an error.
+  if (typeof google !== 'undefined' && google.charts &&
+      typeof google.charts.load === 'function') {
+    resolve();
+  } else {
+    // Try to find existing loader script.
+    let loaderScript = document.querySelector(
+        'script[src="https://www.gstatic.com/charts/loader.js"]');
+    if (!loaderScript) {
+      // If the loader is not present, add it.
+      loaderScript =
+          /** @type {!HTMLScriptElement} */ (document.createElement('script'));
+      // Specify URL directly to pass JS compiler conformance checks.
+      loaderScript.src = 'https://www.gstatic.com/charts/loader.js';
+      document.head.appendChild(loaderScript);
+    }
+    loaderScript.addEventListener('load', resolve);
+    loaderScript.addEventListener('error', reject);
+  }
+});
+
+/**
+ * @typedef {{
+ *   version: (string|undefined),
+ *   packages: (!Array<string>|undefined),
+ *   language: (string|undefined),
+ *   mapsApiKey: (string|undefined),
+ * }}
+ */
+var LoadSettings;
+
+/**
+ * Loads Google Charts API with the selected settings or using defaults.
+ *
+ * The following settings are available:
+ * - version: which version of library to load, default: 'current',
+ * - packages: which chart packages to load, default: ['corechart'],
+ * - language: what language to load library in, default: `lang` attribute on
+ *   `<html>` or 'en' if not specified,
+ * - mapsApiKey: key to use for maps API.
+ *
+ * @param {!LoadSettings=} settings
+ * @return {!Promise}
+ */
+export async function load(settings = {}) {
+  await loaderPromise;
+  const {
+    version = 'current',
+    packages = ['corechart'],
+    language = document.documentElement.lang || 'en',
+    mapsApiKey,
+  } = settings;
+  return google.charts.load(version, {
+    'packages': packages,
+    'language': language,
+    'mapsApiKey': mapsApiKey,
+  });
+}
+
+/**
+ * Creates a DataTable object for use with a chart.
+ *
+ * Multiple different argument types are supported. This is because the
+ * result of loading the JSON data URL is fed into this function for
+ * DataTable construction and its format is unknown.
+ *
+ * The data argument can be one of a few options:
+ *
+ * - null/undefined: An empty DataTable is created. Columns must be added
+ * - !DataTable: The object is simply returned
+ * - {{cols: !Array, rows: !Array}}: A DataTable in object format
+ * - {{cols: !Array}}: A DataTable in object format without rows
+ * - !Array<!Array>: A DataTable in 2D array format
+ *
+ * Un-supported types:
+ *
+ * - Empty !Array<!Array>: (e.g. `[]`) While technically a valid data
+ *   format, this is rejected as charts will not render empty DataTables.
+ *   DataTables must at least have columns specified. An empty array is most
+ *   likely due to a bug or bad data. If one wants an empty DataTable, pass
+ *   no arguments.
+ * - Anything else
+ *
+ * See <a href="https://developers.google.com/chart/interactive/docs/reference#datatable-class">the docs</a> for more details.
+ *
+ * @param {!Array|{cols: !Array, rows: (!Array<!Array>|undefined)}|undefined} data
+ *     the data with which we should use to construct the new DataTable object
+ * @return {!Promise<!google.visualization.DataTable>} promise for the created DataTable
+ */
+export async function dataTable(data) {
+  // Ensure that `google.visualization` namespace is added to the document.
+  await load();
+  if (data == null) {
+    return new google.visualization.DataTable();
+  } else if (data.getNumberOfRows) {
+    // Data is already a DataTable
+    return /** @type {!google.visualization.DataTable} */ (data);
+  } else if (data.cols) {  // data.rows may also be specified
+    // Data is in the form of object DataTable structure
+    return new google.visualization.DataTable(data);
+  } else if (data.length > 0) {
+    // Data is in the form of a two dimensional array.
+    return google.visualization.arrayToDataTable(data);
+  } else if (data.length === 0) {
+    // Chart data was empty.
+    // We throw instead of creating an empty DataTable because most
+    // (if not all) charts will render a sticky error in this situation.
+    throw new Error('Data was empty.');
+    }
+  throw new Error('Data format was not recognized.');
+}
+
+/**
+ * Creates new `ChartWrapper`.
+ * @param {!Element} container Element in which the chart will be drawn
+ * @return {!Promise<!google.visualization.ChartWrapper>}
+ */
+export async function createChartWrapper(container) {
+  // Ensure that `google.visualization` namespace is added to the document.
+  await load();
+  return new google.visualization.ChartWrapper({'container': container});
+}

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -25,6 +25,7 @@
 <script type="module">
 import '@polymer/promise-polyfill/promise-polyfill-lite.js';
 import '../google-chart.js';
+import '../google-chart-loader.js';
 suite('<google-chart>', function() {
   var chart;
   setup(function() {

--- a/test/custom-load-test.html
+++ b/test/custom-load-test.html
@@ -19,7 +19,7 @@
 </test-fixture>
 
 <script type="module">
-  import {load} from '../google-chart-loader.js';
+  import {load} from '../loader.js';
   import '../google-chart.js';
 
   // This test has to run separately because Google Charts API is loaded only once per document.


### PR DESCRIPTION
Remove dependency on google-chart-loader from google-chart and extract
shared loading code to a new module 'loader'.

Loading google-chart (the most common case) is now more efficient. The
code for google-chart-loader does not need be included in the bundle and
executed.