### PR TITLE
Convert google-chart to class-based PolymerElement

### DIFF
--- a/google-chart.js
+++ b/google-chart.js
@@ -8,9 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
 */
 import '@polymer/iron-ajax/iron-request.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { PolymerElement, html } from '@polymer/polymer';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { dataTable, load } from './google-chart-loader.js';
 
 const DEFAULT_EVENTS = ['ready', 'select'];
@@ -102,43 +102,42 @@ on the `html` tag of your document.
 
 @demo
 */
-Polymer({
-  /** @override */
-  _template: html`
-    <style>
-      :host {
-        display: -webkit-flex;
-        display: -ms-flex;
-        display: flex;
-        margin: 0;
-        padding: 0;
-        width: 400px;
-        height: 300px;
-      }
+export class GoogleChart extends PolymerElement {
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: -webkit-flex;
+          display: -ms-flex;
+          display: flex;
+          margin: 0;
+          padding: 0;
+          width: 400px;
+          height: 300px;
+        }
 
-      :host([hidden]) {
-        display: none;
-      }
+        :host([hidden]) {
+          display: none;
+        }
 
-      :host([type="gauge"]) {
-        width: 300px;
-        height: 300px;
-      }
+        :host([type="gauge"]) {
+          width: 300px;
+          height: 300px;
+        }
 
-      #chartdiv {
-        width: 100%;
-      }
+        #chartdiv {
+          width: 100%;
+        }
 
-      /* Workaround for slow initial ready event for tables. */
-      .google-visualization-table-loadtest {
-        padding-left: 6px;
-      }
-    </style>
-    <div id="styles"></div>
-    <div id="chartdiv"></div>
-  `,
-
-  is: 'google-chart',
+        /* Workaround for slow initial ready event for tables. */
+        .google-visualization-table-loadtest {
+          padding-left: 6px;
+        }
+      </style>
+      <div id="styles"></div>
+      <div id="chartdiv"></div>
+    `;
+  }
 
   /**
    * Fired after a chart type is rendered and ready for interaction.
@@ -155,214 +154,226 @@ Polymer({
    */
 
   /** Polymer element properties. */
-  properties: {
-    /**
-     * Sets the type of the chart.
-     *
-     * Should be one of:
-     * - `area`
-     * - `(md-)bar`
-     * - `bubble`
-     * - `calendar`
-     * - `candlestick`
-     * - `column`
-     * - `combo`
-     * - `gauge`
-     * - `geo`
-     * - `histogram`
-     * - `(md-)line`
-     * - `org`
-     * - `pie`
-     * - `sankey`
-     * - `(md-)scatter`
-     * - `stepped-area`
-     * - `table`
-     * - `timeline`
-     * - `treemap`
-     * - `wordtree`
-     *
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
-     * for details.
-     */
-    type: {
-      type: String,
-      value: 'column',
-      observer: '_typeChanged',
-    },
+  static get properties() {
+    return {
+      /**
+       * Sets the type of the chart.
+       *
+       * Should be one of:
+       * - `area`
+       * - `(md-)bar`
+       * - `bubble`
+       * - `calendar`
+       * - `candlestick`
+       * - `column`
+       * - `combo`
+       * - `gauge`
+       * - `geo`
+       * - `histogram`
+       * - `(md-)line`
+       * - `org`
+       * - `pie`
+       * - `sankey`
+       * - `(md-)scatter`
+       * - `stepped-area`
+       * - `table`
+       * - `timeline`
+       * - `treemap`
+       * - `wordtree`
+       *
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
+       * for details.
+       */
+      type: {
+        type: String,
+        value: 'column',
+        observer: '_typeChanged',
+      },
+
+      /**
+       * Enumerates the chart events that should be fired.
+       *
+       * Charts support a variety of events. By default, this element only
+       * fires on `ready` and `select`. If you would like to be notified of
+       * other chart events, use this property to list them.
+       * Events `ready` and `select` are always fired.
+       *
+       * Changes to this property are _not_ observed. Events are attached only
+       * at chart construction time.
+       *
+       * @type {!Array<string>}
+       */
+      events: {
+        type: Array,
+        value: () => [],
+      },
+
+      /**
+       * Sets the options for the chart.
+       *
+       * Example:
+       * <pre>{
+       *   title: "Chart title goes here",
+       *   hAxis: {title: "Categories"},
+       *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
+       *   legend: "none"
+       * };</pre>
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
+       * for the options available to each chart type.
+       *
+       * This property is observed via a deep object observer.
+       * If you would like to make changes to a sub-property, be sure to use the
+       * Polymer method `set`: `googleChart.set('options.vAxis.logScale', true)`
+       * (Note: Missing parent properties are not automatically created.)
+       *
+       * @type {!Object|undefined}
+       */
+      options: {
+        type: Object
+      },
+
+      /**
+       * Sets the data columns for this object.
+       *
+       * When specifying data with `cols` you must also specify `rows`, and
+       * not specify `data`.
+       *
+       * Example:
+       * <pre>[{label: "Categories", type: "string"},
+       *  {label: "Value", type: "number"}]</pre>
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
+       * for column definition format.
+       *
+       * @type {!Array|undefined}
+       */
+      cols: {
+        type: Array,
+        observer: '_rowsOrColumnsChanged',
+      },
+
+      /**
+       * Sets the data rows for this object.
+       *
+       * When specifying data with `rows` you must also specify `cols`, and
+       * not specify `data`.
+       *
+       * Example:
+       * <pre>[["Category 1", 1.0],
+       *  ["Category 2", 1.1]]</pre>
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
+       * for row format.
+       *
+       * @type {!Array<!Array>|undefined}
+       */
+      rows: {
+        type: Array,
+        observer: '_rowsOrColumnsChanged',
+      },
+
+      /**
+       * Sets the entire dataset for this object.
+       * Can be used to provide the data directly, or to provide a URL from
+       * which to request the data.
+       *
+       * The data format can be a two-dimensional array or the DataTable format
+       * expected by Google Charts.
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
+       * for data table format details.
+       *
+       * When specifying data with `data` you must not specify `cols` or `rows`.
+       *
+       * Example:
+       * <pre>[["Categories", "Value"],
+       *  ["Category 1", 1.0],
+       *  ["Category 2", 1.1]]</pre>
+       *
+       * @type {!google.visualization.DataTable|
+       *        !Array<!Array>|
+       *        {cols: !Array, rows: (!Array<!Array>|undefined)}|
+       *        string|
+       *        undefined}
+       */
+      data: {
+        type: String,
+        observer: '_dataChanged',
+      },
+
+      /**
+       * Sets the entire dataset for this object to a Google DataView.
+       *
+       * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#dataview-class">Google Visualization API reference (DataView)</a>
+       * for details.
+       *
+       * When specifying data with `view` you must not specify `data`, `cols` or `rows`.
+       *
+       * @type {!google.visualization.DataView|undefined}
+       */
+      view: {
+        type: Object,
+        observer: '_viewChanged',
+      },
+
+      /**
+       * Selected datapoint(s) in the chart.
+       *
+       * An array of objects, each with a numeric row and/or column property.
+       * `row` and `column` are the zero-based row or column number of an item
+       * in the data table to select.
+       *
+       * To select a whole column, set row to null;
+       * to select a whole row, set column to null.
+       *
+       * Example:
+       * <pre>
+       *   [{row:0,column:1}, {row:1, column:null}]
+       * </pre>
+       *
+       * @type {!Array|undefined}
+       */
+      selection: {
+        type: Array,
+        notify: true,
+        observer: '_setSelection',
+      },
+
+      /**
+       * Whether the chart is currently rendered.
+       */
+      drawn: {
+        type: Boolean,
+        readOnly: true,
+        value: false,
+      },
+
+      /** Internal data displayed on the chart. */
+      _data: {
+        type: Object,
+      },
+    };
+  }
+
+  static get observers() {
+    return [
+      'redraw(_data, options.*)',
+    ];
+  }
+
+  constructor() {
+    super();
 
     /**
-     * Enumerates the chart events that should be fired.
-     *
-     * Charts support a variety of events. By default, this element only
-     * fires on `ready` and `select`. If you would like to be notified of
-     * other chart events, use this property to list them.
-     * Events `ready` and `select` are always fired.
-     *
-     * Changes to this property are _not_ observed. Events are attached only
-     * at chart construction time.
-     *
-     * @type {!Array<string>}
+     * Internal chart object.
+     * @private {!google.visualization.ChartWrapper|null}
      */
-    events: {
-      type: Array,
-      value: () => [],
-    },
+    this._chartWrapper = null;
 
-    /**
-     * Sets the options for the chart.
-     *
-     * Example:
-     * <pre>{
-     *   title: "Chart title goes here",
-     *   hAxis: {title: "Categories"},
-     *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
-     *   legend: "none"
-     * };</pre>
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
-     * for the options available to each chart type.
-     *
-     * This property is observed via a deep object observer.
-     * If you would like to make changes to a sub-property, be sure to use the
-     * Polymer method `set`: `googleChart.set('options.vAxis.logScale', true)`
-     * (Note: Missing parent properties are not automatically created.)
-     *
-     * @type {!Object|undefined}
-     */
-    options: {
-      type: Object
-    },
-
-    /**
-     * Sets the data columns for this object.
-     *
-     * When specifying data with `cols` you must also specify `rows`, and
-     * not specify `data`.
-     *
-     * Example:
-     * <pre>[{label: "Categories", type: "string"},
-     *  {label: "Value", type: "number"}]</pre>
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
-     * for column definition format.
-     *
-     * @type {!Array|undefined}
-     */
-    cols: {
-      type: Array,
-      observer: '_rowsOrColumnsChanged',
-    },
-
-    /**
-     * Sets the data rows for this object.
-     *
-     * When specifying data with `rows` you must also specify `cols`, and
-     * not specify `data`.
-     *
-     * Example:
-     * <pre>[["Category 1", 1.0],
-     *  ["Category 2", 1.1]]</pre>
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
-     * for row format.
-     *
-     * @type {!Array<!Array>|undefined}
-     */
-    rows: {
-      type: Array,
-      observer: '_rowsOrColumnsChanged',
-    },
-
-    /**
-     * Sets the entire dataset for this object.
-     * Can be used to provide the data directly, or to provide a URL from
-     * which to request the data.
-     *
-     * The data format can be a two-dimensional array or the DataTable format
-     * expected by Google Charts.
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
-     * for data table format details.
-     *
-     * When specifying data with `data` you must not specify `cols` or `rows`.
-     *
-     * Example:
-     * <pre>[["Categories", "Value"],
-     *  ["Category 1", 1.0],
-     *  ["Category 2", 1.1]]</pre>
-     *
-     * @type {!google.visualization.DataTable|
-     *        !Array<!Array>|
-     *        {cols: !Array, rows: (!Array<!Array>|undefined)}|
-     *        string|
-     *        undefined}
-     */
-    data: {
-      type: String,
-      observer: '_dataChanged',
-    },
-
-    /**
-     * Sets the entire dataset for this object to a Google DataView.
-     *
-     * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#dataview-class">Google Visualization API reference (DataView)</a>
-     * for details.
-     *
-     * When specifying data with `view` you must not specify `data`, `cols` or `rows`.
-     *
-     * @type {!google.visualization.DataView|undefined}
-     */
-    view: {
-      type: Object,
-      observer: '_viewChanged',
-    },
-
-    /**
-     * Selected datapoint(s) in the chart.
-     *
-     * An array of objects, each with a numeric row and/or column property.
-     * `row` and `column` are the zero-based row or column number of an item
-     * in the data table to select.
-     *
-     * To select a whole column, set row to null;
-     * to select a whole row, set column to null.
-     *
-     * Example:
-     * <pre>
-     *   [{row:0,column:1}, {row:1, column:null}]
-     * </pre>
-     *
-     * @type {!Array|undefined}
-     */
-    selection: {
-      type: Array,
-      notify: true,
-      observer: '_setSelection',
-    },
-
-    /**
-     * Whether the chart is currently rendered.
-     */
-    drawn: {
-      type: Boolean,
-      readOnly: true,
-      value: false,
-    },
-
-    /** Internal data displayed on the chart. */
-    _data: {
-      type: Object,
-    },
-  },
-
-  observers: [
-    'redraw(_data, options.*)',
-  ],
-
-  /**
-   * Internal chart object.
-   * @private {!google.visualization.ChartWrapper|null}
-   */
-  _chartWrapper: null,
+    /** @private {?Debouncer} */
+    this._redrawDebouncer = null;
+  }
 
   /** @override */
   ready() {
+    super.ready();
     createChartWrapper(this.$.chartdiv).then((chartWrapper) => {
       this._chartWrapper = chartWrapper;
       this._typeChanged();
@@ -374,7 +385,7 @@ Polymer({
       });
       this._propagateEvents(DEFAULT_EVENTS, chartWrapper);
     });
-  },
+  }
 
   /** Reacts to chart type change. */
   _typeChanged() {
@@ -394,7 +405,7 @@ Polymer({
       }
     });
     this.redraw();
-  },
+  }
 
   /**
    * Adds listeners to propagate events from the chart.
@@ -405,13 +416,16 @@ Polymer({
   _propagateEvents(events, eventTarget) {
     for (const eventName of events) {
       google.visualization.events.addListener(eventTarget, eventName, (event) => {
-        this.fire(`google-chart-${eventName}`, {
-          chart: this._chartWrapper.getChart(),
-          data: event,
-        });
+        this.dispatchEvent(new CustomEvent(`google-chart-${eventName}`, {
+          bubbles: true,
+          composed: true,
+          detail: {
+            chart: this._chartWrapper.getChart(),
+            data: event,
+          }}));
       });
     }
-  },
+  }
 
   /** Sets the selectiton on the chart. */
   _setSelection() {
@@ -428,7 +442,7 @@ Polymer({
       }
       chart.setSelection(this.selection);
     }
-  },
+  }
 
   /**
    * Redraws the chart.
@@ -442,10 +456,10 @@ Polymer({
     this._chartWrapper.setOptions(this.options || {});
 
     this._setDrawn(false);
-    this.debounce('draw', () => {
+    this._redrawDebouncer = Debouncer.debounce(this._redrawDebouncer, timeOut.after(5), () => {
       this._chartWrapper.draw();
-    }, 5);
-  },
+    });
+  }
 
   /**
    * Returns the chart serialized as an image URI.
@@ -458,13 +472,13 @@ Polymer({
     if (this._chartWrapper == null) return null;
     const chart = this._chartWrapper.getChart();
     return chart && chart.getImageURI();
-  },
+  }
 
   /** Handles changes to the `view` attribute. */
   _viewChanged() {
     if (!this.view) { return; }
     this._data = this.view;
-  },
+  }
 
   /** Handles changes to the rows & columns attributes. */
   async _rowsOrColumnsChanged() {
@@ -477,7 +491,7 @@ Polymer({
     } catch (reason) {
       this.$.chartdiv.textContent = reason;
     }
-  },
+  }
 
   /**
    * Handles changes to the `data` attribute.
@@ -522,15 +536,17 @@ Polymer({
     dataPromise.then(dataTable).then((data) => {
       this._data = data;
     });
-  },
+  }
 
   /**
    * Queries global document head for google charts link#load-css-* and clones
    * them into the local root's div#styles element for shadow dom support.
+   *
+   * @private
    */
-  _localizeGlobalStylesheets: function() {
+  _localizeGlobalStylesheets() {
     // get all gchart stylesheets
-    var stylesheets = dom(document.head)
+    var stylesheets = document.head
         .querySelectorAll('link[rel="stylesheet"][type="text/css"]');
 
     var stylesheetsArray = Array.from(stylesheets);
@@ -546,11 +562,13 @@ Polymer({
         clonedLinkEl.setAttribute('type', 'text/css');
         clonedLinkEl.setAttribute('href', sheetLinkEl.getAttribute('href'));
 
-        dom(this.$.styles).appendChild(clonedLinkEl);
+        this.$.styles.appendChild(clonedLinkEl);
       }
     }
   }
-});
+}
+
+customElements.define('google-chart', GoogleChart);
 
 /**
  * Creates new `ChartWrapper`.

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -24,16 +24,21 @@
 
 <script type="module">
 import '@polymer/promise-polyfill/promise-polyfill-lite.js';
-import '../google-chart.js';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { GoogleChart } from '../google-chart.js';
 suite('<google-chart>', function() {
   var chart;
+  var waitCheckAndDoneDebouncer;
   setup(function() {
     chart = fixture('chart-fixture');
+    waitCheckAndDoneDebouncer = null;
   });
   var waitCheckAndDone = function(check, done) {
     setTimeout(function() {
       if (check()) {
-        chart.debounce('done', done, 100);
+        waitCheckAndDoneDebouncer = Debouncer.debounce(
+            waitCheckAndDoneDebouncer, timeOut.after(100), done);
       } else {
         waitCheckAndDone(check, done);
       }
@@ -66,7 +71,7 @@ suite('<google-chart>', function() {
       chart.type = 'line';
       waitCheckAndDone(function() {
         // A circle indicates the chart type change was drawn:
-        return chart.$$('circle');
+        return chart.shadowRoot.querySelector('circle');
       }, done);
     });
     test('default selection is null', function() {
@@ -76,7 +81,7 @@ suite('<google-chart>', function() {
       chart.selection = [ {row: 0} ];
       waitCheckAndDone(function() {
         // A white stroked rectangle signals the selection was drawn:
-        return chart.$$('rect[stroke="#ffffff"]');
+        return chart.shadowRoot.querySelector('rect[stroke="#ffffff"]');
       }, done);
     });
     test('updates selection', function(done) {
@@ -94,7 +99,7 @@ suite('<google-chart>', function() {
       chart.addEventListener('google-chart-ready', () => {
         // Look for something that can be clicked. Find rectangles for legend
         // and each bar.
-        const rects = chart.$$('#chartdiv')
+        const rects = chart.$['chartdiv']
             .querySelectorAll('rect[fill="#3366cc"]');
         // Click on the last bar ('Something 3').
         rects[3].dispatchEvent(new MouseEvent('click', {bubbles: true}));
@@ -111,7 +116,7 @@ suite('<google-chart>', function() {
           initialDraw = false;
           chart.options = {'title': expectedTitle};
         } else {
-          assert.equal(chart.$$('text').innerHTML, expectedTitle);
+          assert.equal(chart.shadowRoot.querySelector('text').innerHTML, expectedTitle);
           done();
         }
       });
@@ -129,7 +134,7 @@ suite('<google-chart>', function() {
           chart.set('options.title', expectedTitle);
           assert.isFalse(spyRedraw.called);
         } else {
-          assert.equal(chart.$$('text').innerHTML, expectedTitle);
+          assert.equal(chart.shadowRoot.querySelector('text').innerHTML, expectedTitle);
           assert.isTrue(spyRedraw.calledOnce);
           chart._chartWrapper.draw.restore();
           done();
@@ -155,6 +160,19 @@ suite('<google-chart>', function() {
       });
 
       document.body.appendChild(secondChart);
+    });
+  });
+
+  suite('Class', () => {
+    test('can be created', async () => {
+      const chart = new GoogleChart();
+      chart.data = [ ['Data', 'Value'], ['Something', 1] ];
+      const ready = new Promise((resolve) => {
+        chart.addEventListener('google-chart-ready', resolve, {once: true});
+      });
+      document.body.appendChild(chart);
+      await ready;
+      document.body.removeChild(chart);
     });
   });
 
@@ -235,7 +253,7 @@ suite('<google-chart>', function() {
       chart.cols = [ { 'type': 'date' } ];
       chart.rows = [ ['Date(1789, 3, 30)'] ];
       waitCheckAndDone(function() {
-        return chart.$$('#chartdiv').innerHTML ==
+        return chart.$['chartdiv'].innerHTML ==
           'Error: Type mismatch. Value Date(1789, 3, 30) ' +
           'does not match type date in column index 0';
       }, done);


### PR DESCRIPTION
Convert `<google-chart>` from Polymer function `Polymer({ /* ... */ })` to a class-based `class GoogleChart extends PolymerElement`.

Class syntax is more modern and pulls less dependencies. Combined with #255 the dependency on legacy Polymer function is removed completely.
It also creates a constructor and a type for JS compiler.