### PR TITLE
Remove deps: iron-ajax and promise-polyfill

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -56,7 +56,6 @@
   </google-chart>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     var media = window.matchMedia('(min-width: 1024px)');
 
@@ -78,7 +77,6 @@
   </google-chart>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     function getRandomValue() {
       return Math.random() * 10;
@@ -126,7 +124,6 @@
   </div>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     var chart = document.getElementById('selection-chart');
     var label = document.getElementById('selection-label');
@@ -177,7 +174,6 @@
   </div>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     var chart = document.getElementById('mouseover-chart');
     var label = document.getElementById('mouseover-label');
@@ -432,16 +428,15 @@
   <google-chart id="timeline" type="timeline"></google-chart>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
-    import '../google-chart-loader.js';
-    var chart = document.getElementById('timeline');
-    document.createElement('google-chart-loader').dataTable([
+    import {dataTable} from '../loader.js';
+    const chart = document.getElementById('timeline');
+    dataTable([
       ['Name', 'Start', 'End'],
       ['Washington', new Date(1789, 3, 30), new Date(1797, 2, 4)],
       ['Adams', new Date(1797, 2, 4), new Date(1801, 2, 4)],
       ['Jefferson', new Date(1801, 2, 4), new Date(1809, 2, 4)]
-    ]).then(function(dataTable) {
+    ]).then((dataTable) => {
       chart.data = dataTable;
     });
   </script>
@@ -501,7 +496,6 @@
   </google-chart>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     function getRandomGaugeValue(offset, factor) {
       return offset + Math.round(factor * Math.random());
@@ -563,16 +557,15 @@
   </google-chart>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
-    import '../google-chart-loader.js';
-    var chart = document.getElementById('source-datatable');
-    document.createElement('google-chart-loader').dataTable([
+    import {dataTable} from '../loader.js';
+    const chart = document.getElementById('source-datatable');
+    dataTable([
       ['Label', 'Value'],
       ['Memory', 10],
       ['CPU', 12],
       ['Network', 14]
-    ]).then(function(dataTable) {
+    ]).then((dataTable) => {
       chart.data = dataTable;
     });
   </script>
@@ -587,28 +580,24 @@
   <p>DataViews can be altered, but you'll need to call the <code>redraw</code> method afterward.</p>
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
-    import '../google-chart-loader.js';
-    var chart = document.getElementById('source-dataview');
-    var loader = document.createElement('google-chart-loader');
-    loader.dataTable([
+    import {dataTable} from '../loader.js';
+    const chart = document.getElementById('source-dataview');
+    dataTable([
       ['Label', 'Value'],
       ['Memory', 10],
       ['CPU', 12],
       ['Network', 14]
-    ]).then(function(dataTable) {
-      loader.dataView(dataTable).then(function(dataView) {
-        chart.view = dataView;
-        var setRandomRow = function() {
-          var rowCount = dataTable.getNumberOfRows();
-          var row = Math.floor(Math.random() * rowCount);
-          var row2 = (row + 1) % rowCount;
-          chart.view.setRows([row, row2]);
-          chart.redraw();
-        };
-        setInterval(setRandomRow, 3000);
-      });
+    ]).then((dataTable) => {
+      chart.view = new google.visualization.DataView(dataTable);
+      const setRandomRow = () => {
+        const rowCount = dataTable.getNumberOfRows();
+        const row = Math.floor(Math.random() * rowCount);
+        const row2 = (row + 1) % rowCount;
+        chart.view.setRows([row, row2]);
+        chart.redraw();
+      };
+      setInterval(setRandomRow, 3000);
     });
   </script>
 
@@ -617,7 +606,6 @@
   <img id="line-chart-img">
 
   <script type="module">
-    import '@polymer/promise-polyfill/promise-polyfill-lite.js';
     import '../google-chart.js';
     var chart = document.getElementById('line-chart');
     var img = document.getElementById('line-chart-img');

--- a/google-chart.js
+++ b/google-chart.js
@@ -7,7 +7,6 @@ The complete set of contributors may be found at https://polymer.github.io/CONTR
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
 */
-import '@polymer/iron-ajax/iron-request.js';
 import { PolymerElement, html } from '@polymer/polymer';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
@@ -540,12 +539,7 @@ export class GoogleChart extends PolymerElement {
 
     if (isString) {
       // Load data asynchronously, from external URL.
-      var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
-      dataPromise = request.send({
-        url: /** @type {string} */ (data), handleAs: 'json'
-      }).then(function(xhr) {
-        return xhr.response;
-      });
+      dataPromise = fetch(data).then((response) => response.json());
     } else {
       // Data is all ready to be processed.
       dataPromise = Promise.resolve(data);

--- a/package.json
+++ b/package.json
@@ -26,12 +26,10 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@polymer/iron-ajax": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0"
   },
   "devDependencies": {
     "@polymer/iron-component-page": "^3.0.0-pre.18",
-    "@polymer/promise-polyfill": "^3.0.0-pre.18",
     "wct-browser-legacy": "^1.0.1"
   }
 }

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -23,7 +23,6 @@
 </test-fixture>
 
 <script type="module">
-import '@polymer/promise-polyfill/promise-polyfill-lite.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { GoogleChart } from '../google-chart.js';


### PR DESCRIPTION
promise-polyfill is not needed in ES module code because modules rely on promises

iron-ajax can be replaced with built-in fetch which is also available when ES modules are

This reduces the size of google-chart by not loading the legacy API.
On the demo page: the number of request went from 113 to 74 and size dropped from 851K to 744K (delta -107K).