### PR TITLE
Add module entrypoint and @rslawik as contributor

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "type-detect": "1.0.0"
   },
   "main": "google-chart.js",
+  "module": "google-chart.js",
   "contributors": [
     "Wes Alvaro",
-    "Sérgio Gomes"
+    "Sérgio Gomes",
+    "Rafal Slawik"
   ],
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Adding "module" entrypoint allows to load `<google-chart>` from unpkg without specifying filename:
https://unpkg.com/@google-web-components/google-chart?module
This simplifies prototyping and demos.