### PR TITLE
Fix type errors found by tsc

### DIFF
--- a/google-chart.js
+++ b/google-chart.js
@@ -142,14 +142,14 @@ export class GoogleChart extends PolymerElement {
    * Fired after a chart type is rendered and ready for interaction.
    *
    * @event google-chart-ready
-   * @param {{chart: !Object}} The raw chart object.
+   * @param {{chart: !Object}} detail The raw chart object.
    */
 
   /**
    * Fired when the user makes a selection in the chart.
    *
    * @event google-chart-select
-   * @param {{chart: !Object}} The raw chart object.
+   * @param {{chart: !Object}} detail The raw chart object.
    */
 
   /** Polymer element properties. */
@@ -281,7 +281,7 @@ export class GoogleChart extends PolymerElement {
      * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
      * for column definition format.
      *
-     * @type {!Array|undefined}
+     * @type {!Array<*>|undefined}
      */
     this.cols = undefined;
 
@@ -297,7 +297,7 @@ export class GoogleChart extends PolymerElement {
      * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
      * for row format.
      *
-     * @type {!Array<!Array>|undefined}
+     * @type {!Array<!Array<*>>|undefined}
      */
     this.rows = undefined;
 
@@ -319,8 +319,8 @@ export class GoogleChart extends PolymerElement {
      *  ["Category 2", 1.1]]</pre>
      *
      * @type {!google.visualization.DataTable|
-     *        !Array<!Array>|
-     *        {cols: !Array, rows: (!Array<!Array>|undefined)}|
+     *        !Array<!Array<*>>|
+     *        {cols: !Array<*>, rows: (!Array<!Array<*>>|undefined)}|
      *        string|
      *        undefined}
      */
@@ -353,7 +353,7 @@ export class GoogleChart extends PolymerElement {
      *   [{row:0,column:1}, {row:1, column:null}]
      * </pre>
      *
-     * @type {!Array|undefined}
+     * @type {!Array<*>|undefined}
      */
     this.selection = undefined;
 
@@ -390,7 +390,7 @@ export class GoogleChart extends PolymerElement {
   /** @override */
   ready() {
     super.ready();
-    createChartWrapper(this.$.chartdiv).then((chartWrapper) => {
+    createChartWrapper(/** @type {!HTMLElement} */ (this.$['chartdiv'])).then((chartWrapper) => {
       this._chartWrapper = chartWrapper;
       this._typeChanged();
       google.visualization.events.addListener(chartWrapper, 'ready', () => {
@@ -427,6 +427,7 @@ export class GoogleChart extends PolymerElement {
    * Adds listeners to propagate events from the chart.
    *
    * @param {!Array<string>} events
+   * @param {*} eventTarget
    * @private
    */
   _propagateEvents(events, eventTarget) {
@@ -512,10 +513,9 @@ export class GoogleChart extends PolymerElement {
   /**
    * Handles changes to the `data` attribute.
    *
-   * @param {
-   *     !google.visualization.DataTable|
-   *     !Array<!Array>|
-   *     {cols: !Array, rows: (!Array<!Array>|undefined)}|
+   * @param {!google.visualization.DataTable|
+   *     !Array<!Array<*>>|
+   *     {cols: !Array<*>, rows: (!Array<!Array<*>>|undefined)}|
    *     string|
    *     undefined} data The new data value
    */
@@ -539,14 +539,16 @@ export class GoogleChart extends PolymerElement {
 
     if (isString) {
       // Load data asynchronously, from external URL.
-      dataPromise = fetch(data).then((response) => response.json());
+      dataPromise = fetch(data)
+          .then((/** @type {!Response} */ response) => response.json());
     } else {
       // Data is all ready to be processed.
       dataPromise = Promise.resolve(data);
     }
-    dataPromise.then(dataTable).then((data) => {
-      this._data = data;
-    });
+    dataPromise.then(dataTable)
+        .then((/** @type {!google.visualization.DataTable} */ data) => {
+          this._data = data;
+        });
   }
 
   /**

--- a/loader.js
+++ b/loader.js
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at https://polymer.github.io/PATE
 /**
  * Promise that resolves when the gviz loader script is loaded, which
  * provides access to the Google Charts loading API.
- * @type {!Promise}
+ * @type {!Promise<*>}
  */
 const loaderPromise = new Promise((resolve, reject) => {
   // Resolve immediately if the loader script has been added already and
@@ -22,6 +22,7 @@ const loaderPromise = new Promise((resolve, reject) => {
     resolve();
   } else {
     // Try to find existing loader script.
+    /** @type {?HTMLScriptElement} */
     let loaderScript = document.querySelector(
         'script[src="https://www.gstatic.com/charts/loader.js"]');
     if (!loaderScript) {
@@ -58,7 +59,7 @@ var LoadSettings;
  * - mapsApiKey: key to use for maps API.
  *
  * @param {!LoadSettings=} settings
- * @return {!Promise}
+ * @return {!Promise<void>}
  */
 export async function load(settings = {}) {
   await loaderPromise;
@@ -101,7 +102,10 @@ export async function load(settings = {}) {
  *
  * See <a href="https://developers.google.com/chart/interactive/docs/reference#datatable-class">the docs</a> for more details.
  *
- * @param {!Array|{cols: !Array, rows: (!Array<!Array>|undefined)}|undefined} data
+ * @param {!Array<!Array<*>>|
+ *     {cols: !Array<*>, rows: (!Array<!Array<*>>|undefined)}|
+ *     google.visualization.DataTable|
+ *     undefined} data
  *     the data with which we should use to construct the new DataTable object
  * @return {!Promise<!google.visualization.DataTable>} promise for the created DataTable
  */
@@ -130,7 +134,7 @@ export async function dataTable(data) {
 
 /**
  * Creates new `ChartWrapper`.
- * @param {!Element} container Element in which the chart will be drawn
+ * @param {!HTMLElement} container Element in which the chart will be drawn
  * @return {!Promise<!google.visualization.ChartWrapper>}
  */
 export async function createChartWrapper(container) {


### PR DESCRIPTION
Fixes type errors found by tsc. It is the next step for #273.

The remaining errors are not possible to fix because `tsc` and JS compiler have different interpretations of certain JSDoc. For example `{foo: string|undefined}` is an optional property in JSCompiler but a mandatory one for `tsc`. `tsc` also does not run `polymerPass` so it does not understand the private setter for the read only property `drawn`. 