### PR TITLE
Fix lint and conformance error

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -1,16 +1,22 @@
 /**
-@license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at https://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at https://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at https://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
-*/
-import { PolymerElement, html } from '@polymer/polymer';
-import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { createChartWrapper, dataTable, DataTableLike } from './loader.js';
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * https://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * https://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * https://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * https://polymer.github.io/PATENTS.txt
+ */
+
+import {html, PolymerElement} from '@polymer/polymer';
+import {timeOut} from '@polymer/polymer/lib/utils/async';
+import {Debouncer} from '@polymer/polymer/lib/utils/debounce';
+
+import {createChartWrapper, dataTable, DataTableLike} from './loader';
 
 const DEFAULT_EVENTS = ['ready', 'select'];
 
@@ -47,58 +53,68 @@ const CHART_TYPES: Record<string, string|undefined> = {
 };
 
 /**
-`google-chart` encapsulates Google Charts as a web component, allowing you to easily visualize
-data. From simple line charts to complex hierarchical tree maps, the chart element provides a
-number of ready-to-use chart types.
-
-    <google-chart
-      type='pie'
-      options='{"title": "Distribution of days in 2001Q1"}'
-      cols='[{"label":"Month", "type":"string"}, {"label":"Days", "type":"number"}]'
-      rows='[["Jan", 31],["Feb", 28],["Mar", 31]]'>
-    </google-chart>
-
-Note: if you're passing JSON as attributes, single quotes are necessary to be valid JSON.
-See https://www.polymer-project.org/1.0/docs/devguide/properties#configuring-object-and-array-properties.
-
-Height and width are specified as style attributes:
-
-    google-chart {
-      height: 300px;
-      width: 50em;
-    }
-
-Data can be provided in one of three ways:
-
-- Via the `cols` and `rows` attributes:
-
-      cols='[{"label":"Mth", "type":"string"}, {"label":"Days", "type":"number"}]'
-      rows='[["Jan", 31],["Feb", 28],["Mar", 31]]'
-
-- Via the `data` attribute, passing in the data directly:
-
-      data='[["Month", "Days"], ["Jan", 31], ["Feb", 28], ["Mar", 31]]'
-
-- Via the `data` attribute, passing in the URL to a resource containing the
-  data, in JSON format:
-
-      data='http://example.com/chart-data.json'
-
-- Via the `data` attribute, passing in a Google DataTable object:
-
-      data='{{dataTable}}'
-
-- Via the `view` attribute, passing in a Google DataView object:
-
-      view='{{dataView}}'
-
-You can display the charts in locales other than "en" by setting the `lang` attribute
-on the `html` tag of your document.
-
-    <html lang="ja">
-
-@demo demo/index.html
-*/
+ * `google-chart` encapsulates Google Charts as a web component, allowing you to
+ * easily visualize data. From simple line charts to complex hierarchical tree
+ * maps, the chart element provides a number of ready-to-use chart types.
+ *
+ * ```html
+ * <google-chart
+ *     type='pie'
+ *     options='{"title": "Distribution of days in 2001Q1"}'
+ *     cols='[{"label":"Month", "type":"string"}, {"label":"Days",
+ *         "type":"number"}]' rows='[["Jan", 31],["Feb", 28],["Mar", 31]]'>
+ *   </google-chart>
+ * ```
+ *
+ * Note: if you're passing JSON as attributes, single quotes are necessary to be
+ * valid JSON. See
+ * https://www.polymer-project.org/1.0/docs/devguide/properties#configuring-object-and-array-properties.
+ *
+ * Height and width are specified as style attributes:
+ * ```css
+ * google-chart {
+ *   height: 300px;
+ *   width: 50em;
+ * }
+ * ```
+ *
+ * Data can be provided in one of three ways:
+ *
+ * - Via the `cols` and `rows` attributes:
+ *   ```
+ *   cols='[{"label":"Mth", "type":"string"},{"label":"Days", "type":"number"}]'
+ *   rows='[["Jan", 31],["Feb", 28],["Mar", 31]]'
+ *   ```
+ *
+ * - Via the `data` attribute, passing in the data directly:
+ *   ```
+ *   data='[["Month", "Days"], ["Jan", 31], ["Feb", 28], ["Mar", 31]]'
+ *   ```
+ *
+ * - Via the `data` attribute, passing in the URL to a resource containing the
+ *   data, in JSON format:
+ *   ```
+ *   data='http://example.com/chart-data.json'
+ *   ```
+ *
+ * - Via the `data` attribute, passing in a Google DataTable object:
+ *   ```
+ *   data='{{dataTable}}'
+ *   ```
+ *
+ * - Via the `view` attribute, passing in a Google DataView object:
+ *   ```
+ *   view='{{dataView}}'
+ *   ```
+ *
+ * You can display the charts in locales other than "en" by setting the `lang`
+ * attribute on the `html` tag of your document:
+ * ```
+ * <html lang="ja">
+ * ```
+ *
+ * @demo demo/index.html
+ */
 export class GoogleChart extends PolymerElement {
   static get template() {
     return html`
@@ -155,31 +171,31 @@ export class GoogleChart extends PolymerElement {
     return {
       type: {
         type: String,
-        observer: GoogleChart.prototype._typeChanged,
+        observer: GoogleChart.prototype.typeChanged,
       },
       events: Array,
       options: Object,
       cols: {
         type: Array,
-        observer: GoogleChart.prototype._rowsOrColumnsChanged,
+        observer: GoogleChart.prototype.rowsOrColumnsChanged,
       },
       rows: {
         type: Array,
-        observer: GoogleChart.prototype._rowsOrColumnsChanged,
+        observer: GoogleChart.prototype.rowsOrColumnsChanged,
       },
       data: {
         // Note: type: String, because it is parsed manually in the observer.
         type: String,
-        observer: GoogleChart.prototype._dataChanged,
+        observer: GoogleChart.prototype.dataChanged,
       },
       view: {
         type: Object,
-        observer: GoogleChart.prototype._viewChanged,
+        observer: GoogleChart.prototype.viewChanged,
       },
       selection: {
         type: Array,
         notify: true,
-        observer: GoogleChart.prototype._setSelection,
+        observer: GoogleChart.prototype.selectionChanged,
       },
       drawn: {
         type: Boolean,
@@ -220,8 +236,9 @@ export class GoogleChart extends PolymerElement {
    * - `treemap`
    * - `wordtree`
    *
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
-   * for details.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google
+   * Visualization API reference (Chart Gallery)</a> for details.
    */
   type = 'column';
 
@@ -248,8 +265,10 @@ export class GoogleChart extends PolymerElement {
    *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
    *   legend: "none"
    * };</pre>
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google Visualization API reference (Chart Gallery)</a>
-   * for the options available to each chart type.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google
+   * Visualization API reference (Chart Gallery)</a> for the options available
+   * to each chart type.
    *
    * This property is observed via a deep object observer.
    * If you would like to make changes to a sub-property, be sure to use the
@@ -267,8 +286,9 @@ export class GoogleChart extends PolymerElement {
    * Example:
    * <pre>[{label: "Categories", type: "string"},
    *  {label: "Value", type: "number"}]</pre>
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google Visualization API reference (addColumn)</a>
-   * for column definition format.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google
+   * Visualization API reference (addColumn)</a> for column definition format.
    */
   cols: unknown[]|undefined = undefined;
 
@@ -281,8 +301,9 @@ export class GoogleChart extends PolymerElement {
    * Example:
    * <pre>[["Category 1", 1.0],
    *  ["Category 2", 1.1]]</pre>
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google Visualization API reference (addRow)</a>
-   * for row format.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google
+   * Visualization API reference (addRow)</a> for row format.
    */
   rows: unknown[][]|undefined = undefined;
 
@@ -293,8 +314,10 @@ export class GoogleChart extends PolymerElement {
    *
    * The data format can be a two-dimensional array or the DataTable format
    * expected by Google Charts.
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google Visualization API reference (DataTable constructor)</a>
-   * for data table format details.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable">Google
+   * Visualization API reference (DataTable constructor)</a> for data table
+   * format details.
    *
    * When specifying data with `data` you must not specify `cols` or `rows`.
    *
@@ -310,10 +333,12 @@ export class GoogleChart extends PolymerElement {
   /**
    * Sets the entire dataset for this object to a Google DataView.
    *
-   * See <a href="https://google-developers.appspot.com/chart/interactive/docs/reference#dataview-class">Google Visualization API reference (DataView)</a>
-   * for details.
+   * See <a
+   * href="https://google-developers.appspot.com/chart/interactive/docs/reference#dataview-class">Google
+   * Visualization API reference (DataView)</a> for details.
    *
-   * When specifying data with `view` you must not specify `data`, `cols` or `rows`.
+   * When specifying data with `view` you must not specify `data`, `cols` or
+   * `rows`.
    */
   view: google.visualization.DataView|undefined = undefined;
 
@@ -339,82 +364,92 @@ export class GoogleChart extends PolymerElement {
    */
   drawn = false;
   // This method is generated by Polymer.
-  private _setDrawn!: (drawn: boolean) => void;
+  // tslint:disable-next-line:enforce-name-casing
+  protected _setDrawn!: (drawn: boolean) => void;
 
   /**
    * Internal data displayed on the chart.
    *
    * This property has protected visibility because it is used from an observer.
    */
-  protected _data: google.visualization.DataTable|google.visualization.DataView
-      |undefined = undefined;
+  // tslint:disable-next-line:enforce-name-casing
+  protected _data: google.visualization.DataTable|google.visualization.DataView|
+      undefined = undefined;
 
   /**
    * Internal chart object.
    */
-  private _chartWrapper: google.visualization.ChartWrapper|null = null;
+  private chartWrapper: google.visualization.ChartWrapper|null = null;
 
-  private _redrawDebouncer: Debouncer|null = null;
+  private redrawDebouncer: Debouncer|null = null;
 
   /** @override */
   ready() {
     super.ready();
-    createChartWrapper(this.$['chartdiv'] as HTMLElement).then((chartWrapper) => {
-      this._chartWrapper = chartWrapper;
-      this._typeChanged();
-      google.visualization.events.addListener(chartWrapper, 'ready', () => {
-        this._setDrawn(true);
-      });
-      google.visualization.events.addListener(chartWrapper, 'select', () => {
-        this.selection = chartWrapper.getChart().getSelection();
-      });
-      this._propagateEvents(DEFAULT_EVENTS, chartWrapper);
-    });
+    createChartWrapper(this.$['chartdiv'] as HTMLElement)
+        .then((chartWrapper) => {
+          this.chartWrapper = chartWrapper;
+          this.typeChanged();
+          google.visualization.events.addListener(chartWrapper, 'ready', () => {
+            this._setDrawn(true);
+          });
+          google.visualization.events.addListener(
+              chartWrapper, 'select', () => {
+                this.selection = chartWrapper.getChart().getSelection();
+              });
+          this.propagateEvents(DEFAULT_EVENTS, chartWrapper);
+        });
   }
 
   /** Reacts to chart type change. */
-  _typeChanged() {
-    if (this._chartWrapper == null) return;
-    this._chartWrapper.setChartType(CHART_TYPES[this.type] || this.type);
-    const lastChart = this._chartWrapper.getChart();
-    google.visualization.events.addOneTimeListener(this._chartWrapper, 'ready', () => {
-      // Ready event fires after `_chartWrapper` is initialized.
-      const chart = this._chartWrapper!.getChart();
-      if (chart !== lastChart) {
-        this._propagateEvents(this.events.filter((eventName) => !DEFAULT_EVENTS.includes(eventName)), chart);
-      }
-      if (!this.$.styles.children.length) {
-        this._localizeGlobalStylesheets();
-      }
-      if (this.selection) {
-        this._setSelection();
-      }
-    });
+  protected typeChanged() {
+    if (this.chartWrapper == null) return;
+    this.chartWrapper.setChartType(CHART_TYPES[this.type] || this.type);
+    const lastChart = this.chartWrapper.getChart();
+    google.visualization.events.addOneTimeListener(
+        this.chartWrapper, 'ready', () => {
+          // Ready event fires after `chartWrapper` is initialized.
+          const chart = this.chartWrapper!.getChart();
+          if (chart !== lastChart) {
+            this.propagateEvents(
+                this.events.filter(
+                    (eventName) => !DEFAULT_EVENTS.includes(eventName)),
+                chart);
+          }
+          if (!this.$['styles'].children.length) {
+            this.localizeGlobalStylesheets();
+          }
+          if (this.selection) {
+            this.selectionChanged();
+          }
+        });
     this.redraw();
   }
 
   /**
    * Adds listeners to propagate events from the chart.
    */
-  private _propagateEvents(events: string[], eventTarget: unknown) {
+  private propagateEvents(events: string[], eventTarget: unknown) {
     for (const eventName of events) {
-      google.visualization.events.addListener(eventTarget, eventName, (event:unknown) => {
-        this.dispatchEvent(new CustomEvent(`google-chart-${eventName}`, {
-          bubbles: true,
-          composed: true,
-          detail: {
-            // Events fire after `_chartWrapper` is initialized.
-            chart: this._chartWrapper!.getChart(),
-            data: event,
-          }}));
-      });
+      google.visualization.events.addListener(
+          eventTarget, eventName, (event: unknown) => {
+            this.dispatchEvent(new CustomEvent(`google-chart-${eventName}`, {
+              bubbles: true,
+              composed: true,
+              detail: {
+                // Events fire after `chartWrapper` is initialized.
+                chart: this.chartWrapper!.getChart(),
+                data: event,
+              }
+            }));
+          });
     }
   }
 
   /** Sets the selectiton on the chart. */
-  _setSelection() {
-    if (this._chartWrapper == null) return;
-    const chart = this._chartWrapper.getChart();
+  protected selectionChanged() {
+    if (this.chartWrapper == null) return;
+    const chart = this.chartWrapper.getChart();
     if (chart == null) return;
     if (chart.setSelection) {
       // Workaround for timeline chart which emits select event on setSelection.
@@ -435,39 +470,41 @@ export class GoogleChart extends PolymerElement {
    * Call manually to handle view updates, page resizes, etc.
    */
   redraw() {
-    if (this._chartWrapper == null || this._data == null) return;
+    if (this.chartWrapper == null || this._data == null) return;
     // `ChartWrapper` can be initialized with `DataView` instead of `DataTable`.
-    this._chartWrapper.setDataTable(this._data as google.visualization.DataTable);
-    this._chartWrapper.setOptions(this.options || {});
+    this.chartWrapper.setDataTable(
+        this._data as google.visualization.DataTable);
+    this.chartWrapper.setOptions(this.options || {});
 
     this._setDrawn(false);
-    this._redrawDebouncer = Debouncer.debounce(this._redrawDebouncer, timeOut.after(5), () => {
-      // Drawing happens after `_chartWrapper` is initialized.
-      this._chartWrapper!.draw();
-    });
+    this.redrawDebouncer =
+        Debouncer.debounce(this.redrawDebouncer, timeOut.after(5), () => {
+          // Drawing happens after `chartWrapper` is initialized.
+          this.chartWrapper!.draw();
+        });
   }
 
   /**
    * Returns the chart serialized as an image URI.
    *
-   * Call this after the chart is drawn (google-chart-ready event).
-   *
-   * @return {?string} Returns image URI.
+   * Call this after the chart is drawn (`google-chart-ready` event).
    */
-  get imageURI() {
-    if (this._chartWrapper == null) return null;
-    const chart = this._chartWrapper.getChart();
+  get imageURI(): string|null {
+    if (this.chartWrapper == null) return null;
+    const chart = this.chartWrapper.getChart();
     return chart && chart.getImageURI();
   }
 
   /** Handles changes to the `view` attribute. */
-  _viewChanged() {
-    if (!this.view) { return; }
+  protected viewChanged() {
+    if (!this.view) {
+      return;
+    }
     this._data = this.view;
   }
 
   /** Handles changes to the rows & columns attributes. */
-  async _rowsOrColumnsChanged() {
+  protected async rowsOrColumnsChanged() {
     const {rows, cols} = this;
     if (!rows || !cols) return;
     try {
@@ -475,19 +512,21 @@ export class GoogleChart extends PolymerElement {
       dt.addRows(rows);
       this._data = dt;
     } catch (reason) {
-      this.$.chartdiv.textContent = reason;
+      this.$['chartdiv'].textContent = reason;
     }
   }
 
   /**
    * Handles changes to the `data` attribute.
    */
-  _dataChanged() {
+  protected dataChanged() {
     let data = this.data;
-    var dataPromise;
-    if (!data) { return; }
+    let dataPromise;
+    if (!data) {
+      return;
+    }
 
-    var isString = false;
+    let isString = false;
 
     // Polymer 2 will not call observer if type:Object is set and fails, so
     // we must parse the string ourselves.
@@ -496,50 +535,39 @@ export class GoogleChart extends PolymerElement {
       // serialized array.
       data = JSON.parse(data as string);
     } catch (e) {
-      isString = typeof data == 'string' || data instanceof String;
+      isString = typeof data === 'string' || data instanceof String;
     }
 
     if (isString) {
       // Load data asynchronously, from external URL.
-      dataPromise = fetch(data as string)
-          .then((/** @type {!Response} */ response) => response.json());
+      dataPromise = fetch(data as string).then(response => response.json());
     } else {
       // Data is all ready to be processed.
       dataPromise = Promise.resolve(data);
     }
-    dataPromise.then(dataTable)
-        .then((/** @type {!google.visualization.DataTable} */ data) => {
-          this._data = data;
-        });
+    dataPromise.then(dataTable).then(data => {
+      this._data = data;
+    });
   }
 
   /**
-   * Queries global document head for google charts link#load-css-* and clones
-   * them into the local root's div#styles element for shadow dom support.
-   *
-   * @private
+   * Queries global document head for Google Charts `link#load-css-*` and clones
+   * them into the local root's `div#styles` element for shadow dom support.
    */
-  _localizeGlobalStylesheets() {
-    // get all gchart stylesheets
-    var stylesheets = document.head
-        .querySelectorAll('link[rel="stylesheet"][type="text/css"]');
+  private localizeGlobalStylesheets() {
+    // Get all Google Charts stylesheets.
+    const stylesheets = Array.from(document.head.querySelectorAll(
+        'link[rel="stylesheet"][type="text/css"][id^="load-css-"]'));
 
-    var stylesheetsArray = Array.from(stylesheets);
+    for (const stylesheet of stylesheets) {
+      // Clone necessary stylesheet attributes.
+      const clonedStylesheet = document.createElement('link');
+      clonedStylesheet.setAttribute('rel', 'stylesheet');
+      clonedStylesheet.setAttribute('type', 'text/css');
+      // `href` is always present.
+      clonedStylesheet.setAttribute('href', stylesheet.getAttribute('href')!);
 
-    for (var i = 0; i < stylesheetsArray.length; i++) {
-      var sheetLinkEl = stylesheetsArray[i];
-      var isGchartStylesheet = sheetLinkEl.id.indexOf('load-css-') == 0;
-
-      if (isGchartStylesheet) {
-        // clone necessary stylesheet attributes
-        var clonedLinkEl = document.createElement('link');
-        clonedLinkEl.setAttribute('rel', 'stylesheet');
-        clonedLinkEl.setAttribute('type', 'text/css');
-        // href is always present
-        clonedLinkEl.setAttribute('href', sheetLinkEl.getAttribute('href')!);
-
-        this.$.styles.appendChild(clonedLinkEl);
-      }
+      this.$['styles'].appendChild(clonedStylesheet);
     }
   }
 }

--- a/loader.ts
+++ b/loader.ts
@@ -1,17 +1,20 @@
 /**
-@license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at https://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at https://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at https://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at https://polymer.github.io/PATENTS.txt
-*/
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * https://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * https://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * https://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * https://polymer.github.io/PATENTS.txt
+ */
 
 /**
  * Promise that resolves when the gviz loader script is loaded, which
  * provides access to the Google Charts loading API.
- * @type {!Promise<*>}
  */
 const loaderPromise = new Promise((resolve, reject) => {
   // Resolve immediately if the loader script has been added already and
@@ -22,12 +25,11 @@ const loaderPromise = new Promise((resolve, reject) => {
     resolve();
   } else {
     // Try to find existing loader script.
-    let loaderScript: HTMLScriptElement | null = document.querySelector(
+    let loaderScript: HTMLScriptElement|null = document.querySelector(
         'script[src="https://www.gstatic.com/charts/loader.js"]');
     if (!loaderScript) {
       // If the loader is not present, add it.
-      loaderScript =
-          /** @type {!HTMLScriptElement} */ (document.createElement('script'));
+      loaderScript = document.createElement('script');
       // Specify URL directly to pass JS compiler conformance checks.
       loaderScript.src = 'https://www.gstatic.com/charts/loader.js';
       document.head.appendChild(loaderScript);
@@ -38,10 +40,10 @@ const loaderPromise = new Promise((resolve, reject) => {
 });
 
 interface LoadSettings {
-  version?: string,
-  packages?: string[],
-  language?: string,
-  mapsApiKey?: string,
+  version?: string;
+  packages?: string[];
+  language?: string;
+  mapsApiKey?: string;
 }
 
 /**
@@ -53,10 +55,8 @@ interface LoadSettings {
  * - language: what language to load library in, default: `lang` attribute on
  *   `<html>` or 'en' if not specified,
  * - mapsApiKey: key to use for maps API.
- *
- * @return {!Promise<void>}
  */
-export async function load(settings: LoadSettings = {}) {
+export async function load(settings: LoadSettings = {}): Promise<void> {
   await loaderPromise;
   const {
     version = 'current',
@@ -72,8 +72,8 @@ export async function load(settings: LoadSettings = {}) {
 }
 
 /** Types that can be converted to `DataTable`. */
-export type DataTableLike = unknown[][]|{cols: unknown[], rows?: unknown[][]}
-    |google.visualization.DataTable;
+export type DataTableLike = unknown[][]|{cols: unknown[], rows?: unknown[][]}|
+                            google.visualization.DataTable;
 
 /**
  * Creates a DataTable object for use with a chart.
@@ -99,10 +99,11 @@ export type DataTableLike = unknown[][]|{cols: unknown[], rows?: unknown[][]}
  *   no arguments.
  * - Anything else
  *
- * See <a href="https://developers.google.com/chart/interactive/docs/reference#datatable-class">the docs</a> for more details.
+ * See <a
+ * href="https://developers.google.com/chart/interactive/docs/reference#datatable-class">the
+ * docs</a> for more details.
  *
  * @param data The data which we should use to construct new DataTable object
- * @return Promise for the created DataTable
  */
 export async function dataTable(data: DataTableLike|undefined):
     Promise<google.visualization.DataTable> {
@@ -113,7 +114,9 @@ export async function dataTable(data: DataTableLike|undefined):
   } else if ((data as google.visualization.DataTable).getNumberOfRows!) {
     // Data is already a DataTable
     return data as google.visualization.DataTable;
-  } else if ((data as {cols: unknown[]}).cols) {  // data.rows may also be specified
+  } else if ((data as {
+               cols: unknown[]
+             }).cols) {  // data.rows may also be specified
     // Data is in the form of object DataTable structure
     return new google.visualization.DataTable(data);
   } else if ((data as unknown[][]).length > 0) {
@@ -124,20 +127,20 @@ export async function dataTable(data: DataTableLike|undefined):
     // We throw instead of creating an empty DataTable because most
     // (if not all) charts will render a sticky error in this situation.
     throw new Error('Data was empty.');
-    }
+  }
   throw new Error('Data format was not recognized.');
 }
 
 /**
  * Creates new `ChartWrapper`.
  * @param container Element in which the chart will be drawn
- * @return {!Promise<!google.visualization.ChartWrapper>}
  */
-export async function createChartWrapper(container: HTMLElement) {
+export async function createChartWrapper(container: HTMLElement):
+    Promise<google.visualization.ChartWrapper> {
   // Ensure that `google.visualization` namespace is added to the document.
   await load();
   // Typings suggest that `chartType` is required in `ChartSpecs`, but it works
   // without it.
   return new google.visualization.ChartWrapper(
-      {'container': container} as google.visualization.ChartSpecs);
+      {'container': container} as unknown as google.visualization.ChartSpecs);
 }

--- a/test/basic-tests.html
+++ b/test/basic-tests.html
@@ -129,7 +129,7 @@ suite('<google-chart>', function() {
       var initialDraw = true;
       chart.addEventListener('google-chart-ready', function() {
         if (initialDraw) {
-          spyRedraw = sinon.spy(chart._chartWrapper, 'draw');
+          spyRedraw = sinon.spy(chart.chartWrapper, 'draw');
           initialDraw = false;
           chart.set('options.title', 'Debounced Title');
           chart.set('options.title', expectedTitle);
@@ -137,7 +137,7 @@ suite('<google-chart>', function() {
         } else {
           assert.equal(chart.shadowRoot.querySelector('text').innerHTML, expectedTitle);
           assert.isTrue(spyRedraw.calledOnce);
-          chart._chartWrapper.draw.restore();
+          chart.chartWrapper.draw.restore();
           done();
         }
       });
@@ -226,7 +226,7 @@ suite('<google-chart>', function() {
       chart.events = ['onmouseover'];
       chart.addEventListener('google-chart-ready', function() {
         google.visualization.events.trigger(
-            chart._chartWrapper.getChart(), 'onmouseover', {'row': 1, 'column': 5});
+            chart.chartWrapper.getChart(), 'onmouseover', {'row': 1, 'column': 5});
       });
       chart.addEventListener('google-chart-onmouseover', function(e) {
         assert.equal(e.detail.data.row, 1);


### PR DESCRIPTION
A lot of code was reformatted due to fixes in JSDoc, replacing var or
field renaming.

The only meaningful change is in `localizeGlobalStylesheets`. It uses
the CSS selector to select stylesheets with certain ids. Previously it
took all of them and filtered in the code.