### PR TITLE
Add to HTMLElementTagNameMap

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -573,3 +573,9 @@ export class GoogleChart extends PolymerElement {
 }
 
 customElements.define('google-chart', GoogleChart);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'google-chart': GoogleChart;
+  }
+}


### PR DESCRIPTION
This allows TypeScript to recognise `<google-chart>` as a custom element.

Example of inferring the correct type:

```
const chart = document.createElement('google-chart');
```