### PR TITLE
Migrate to LitElement

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -117,6 +117,7 @@ const CHART_TYPES: Record<string, string|undefined> = {
  * @demo demo/index.html
  */
 export class GoogleChart extends LitElement {
+  /** @nocollapse */
   static styles = css`
     :host {
       display: -webkit-flex;

--- a/google-chart.ts
+++ b/google-chart.ts
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-import {observe, property} from '@polymer/decorators';
-import {html, PolymerElement} from '@polymer/polymer';
-import {timeOut} from '@polymer/polymer/lib/utils/async';
-import {Debouncer} from '@polymer/polymer/lib/utils/debounce';
+import {html, css, LitElement, property} from 'lit-element';
 
 import {createChartWrapper, dataTable, DataTableLike} from './loader';
 
@@ -119,42 +116,36 @@ const CHART_TYPES: Record<string, string|undefined> = {
  *
  * @demo demo/index.html
  */
-export class GoogleChart extends PolymerElement {
-  static get template() {
-    return html`
-      <style>
-        :host {
-          display: -webkit-flex;
-          display: -ms-flex;
-          display: flex;
-          margin: 0;
-          padding: 0;
-          width: 400px;
-          height: 300px;
-        }
+export class GoogleChart extends LitElement {
+  static styles = css`
+    :host {
+      display: -webkit-flex;
+      display: -ms-flex;
+      display: flex;
+      margin: 0;
+      padding: 0;
+      width: 400px;
+      height: 300px;
+    }
 
-        :host([hidden]) {
-          display: none;
-        }
+    :host([hidden]) {
+      display: none;
+    }
 
-        :host([type="gauge"]) {
-          width: 300px;
-          height: 300px;
-        }
+    :host([type="gauge"]) {
+      width: 300px;
+      height: 300px;
+    }
 
-        #chartdiv {
-          width: 100%;
-        }
+    #chartdiv {
+      width: 100%;
+    }
 
-        /* Workaround for slow initial ready event for tables. */
-        .google-visualization-table-loadtest {
-          padding-left: 6px;
-        }
-      </style>
-      <div id="styles"></div>
-      <div id="chartdiv"></div>
-    `;
-  }
+    /* Workaround for slow initial ready event for tables. */
+    .google-visualization-table-loadtest {
+      padding-left: 6px;
+    }
+  `;
 
   /**
    * Fired after a chart type is rendered and ready for interaction.
@@ -171,7 +162,7 @@ export class GoogleChart extends PolymerElement {
    */
 
   /**
-   * Sets the type of the chart.
+   * Type of the chart.
    *
    * Should be one of:
    * - `area`
@@ -199,7 +190,7 @@ export class GoogleChart extends PolymerElement {
    * href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google
    * Visualization API reference (Chart Gallery)</a> for details.
    */
-  @property({type: String, observer: GoogleChart.prototype.typeChanged})
+  @property({type: String, reflect: true})
   type = 'column';
 
   /**
@@ -220,23 +211,29 @@ export class GoogleChart extends PolymerElement {
    * Sets the options for the chart.
    *
    * Example:
-   * <pre>{
+   * ```
+   * {
    *   title: "Chart title goes here",
    *   hAxis: {title: "Categories"},
    *   vAxis: {title: "Values", minValue: 0, maxValue: 2},
    *   legend: "none"
-   * };</pre>
+   * }
+   * ```
    * See <a
    * href="https://google-developers.appspot.com/chart/interactive/docs/gallery">Google
    * Visualization API reference (Chart Gallery)</a> for the options available
    * to each chart type.
    *
-   * This property is observed via a deep object observer.
-   * If you would like to make changes to a sub-property, be sure to use the
-   * Polymer method `set`: `googleChart.set('options.vAxis.logScale', true)`
+   * Setting this property always redraws the chart. If you would like to make
+   * changes to a sub-property, be sure to reassign the property:
+   * ```
+   * const options = googleChart.options;
+   * options.vAxis.logScale = true;
+   * googleChart.options = options;
+   * ```
    * (Note: Missing parent properties are not automatically created.)
    */
-  @property({type: Object})
+  @property({type: Object, hasChanged: () => true})
   options: {}|undefined = undefined;
 
   /**
@@ -252,7 +249,7 @@ export class GoogleChart extends PolymerElement {
    * href="https://google-developers.appspot.com/chart/interactive/docs/reference#DataTable_addColumn">Google
    * Visualization API reference (addColumn)</a> for column definition format.
    */
-  @property({type: Array, observer: GoogleChart.prototype.rowsOrColumnsChanged})
+  @property({type: Array})
   cols: unknown[]|undefined = undefined;
 
   /**
@@ -268,7 +265,7 @@ export class GoogleChart extends PolymerElement {
    * href="https://google-developers.appspot.com/chart/interactive/docs/reference#addrow">Google
    * Visualization API reference (addRow)</a> for row format.
    */
-  @property({type: Array, observer: GoogleChart.prototype.rowsOrColumnsChanged})
+  @property({type: Array})
   rows: unknown[][]|undefined = undefined;
 
   /**
@@ -293,7 +290,7 @@ export class GoogleChart extends PolymerElement {
    * ```
    */
   // Note: type: String, because it is parsed manually in the observer.
-  @property({type: String, observer: GoogleChart.prototype.dataChanged})
+  @property({type: String})
   data: DataTableLike|string|undefined = undefined;
 
   /**
@@ -306,7 +303,7 @@ export class GoogleChart extends PolymerElement {
    * When specifying data with `view` you must not specify `data`, `cols` or
    * `rows`.
    */
-  @property({type: Object, observer: GoogleChart.prototype.viewChanged})
+  @property({type: Object})
   view: google.visualization.DataView|undefined = undefined;
 
   /**
@@ -324,23 +321,14 @@ export class GoogleChart extends PolymerElement {
    * [{row:0,column:1}, {row:1, column:null}]
    * ```
    */
-  @property({
-    type: Array,
-    notify: true,
-    observer: GoogleChart.prototype.selectionChanged,
-  })
+  @property({type: Array})
   selection: unknown[]|undefined = undefined;
 
   /**
    * Whether the chart is currently rendered.
+   * @export
    */
-  @property({type: Boolean, readOnly: true})
   drawn = false;
-
-  /** @export */
-  // This method is generated by Polymer.
-  // tslint:disable-next-line:enforce-name-casing
-  _setDrawn!: (drawn: boolean) => void;
 
   /**
    * Internal data displayed on the chart.
@@ -354,17 +342,24 @@ export class GoogleChart extends PolymerElement {
    */
   private chartWrapper: google.visualization.ChartWrapper|null = null;
 
-  private redrawDebouncer: Debouncer|null = null;
+  private redrawTimeoutId: number|undefined = undefined;
 
   /** @override */
-  ready() {
-    super.ready();
-    createChartWrapper(this.$['chartdiv'] as HTMLElement)
+  protected render() {
+    return html`
+      <div id="styles"></div>
+      <div id="chartdiv"></div>
+    `;
+  }
+
+  /** @override */
+  protected firstUpdated() {
+    createChartWrapper(this.shadowRoot!.getElementById('chartdiv')!)
         .then((chartWrapper) => {
           this.chartWrapper = chartWrapper;
           this.typeChanged();
           google.visualization.events.addListener(chartWrapper, 'ready', () => {
-            this._setDrawn(true);
+            this.drawn = true;
           });
           google.visualization.events.addListener(
               chartWrapper, 'select', () => {
@@ -374,8 +369,32 @@ export class GoogleChart extends PolymerElement {
         });
   }
 
+  /** @override */
+  protected updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('type')) this.typeChanged();
+    if (changedProperties.has('rows') || changedProperties.has('cols')) {
+      this.rowsOrColumnsChanged();
+    }
+    if (changedProperties.has('data')) this.dataChanged();
+    if (changedProperties.has('view')) this.viewChanged();
+    if (changedProperties.has('_data') ||
+        changedProperties.has('options')) this.redraw();
+    if (changedProperties.has('selection')) {
+      this.selectionChanged();
+      // Fire event for backwards compatibility with Polymer two-way data
+      // binding: `@property({notify: true})`.
+      this.dispatchEvent(new CustomEvent('selection-changed', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          'value': this.selection,
+        },
+      }));
+    }
+  }
+
   /** Reacts to chart type change. */
-  protected typeChanged() {
+  private typeChanged() {
     if (this.chartWrapper == null) return;
     this.chartWrapper.setChartType(CHART_TYPES[this.type] || this.type);
     const lastChart = this.chartWrapper.getChart();
@@ -389,8 +408,9 @@ export class GoogleChart extends PolymerElement {
                     (eventName) => !DEFAULT_EVENTS.includes(eventName)),
                 chart);
           }
-          if (!this.$['styles'].children.length) {
-            this.localizeGlobalStylesheets();
+          const stylesDiv = this.shadowRoot!.getElementById('styles')!;
+          if (!stylesDiv.children.length) {
+            this.localizeGlobalStylesheets(stylesDiv);
           }
           if (this.selection) {
             this.selectionChanged();
@@ -420,7 +440,7 @@ export class GoogleChart extends PolymerElement {
   }
 
   /** Sets the selectiton on the chart. */
-  protected selectionChanged() {
+  private selectionChanged() {
     if (this.chartWrapper == null) return;
     const chart = this.chartWrapper.getChart();
     if (chart == null) return;
@@ -442,7 +462,6 @@ export class GoogleChart extends PolymerElement {
    * Called automatically when data/type/selection attributes change.
    * Call manually to handle view updates, page resizes, etc.
    */
-  @observe('_data', 'options.*')
   redraw() {
     if (this.chartWrapper == null || this._data == null) return;
     // `ChartWrapper` can be initialized with `DataView` instead of `DataTable`.
@@ -450,12 +469,12 @@ export class GoogleChart extends PolymerElement {
         this._data as google.visualization.DataTable);
     this.chartWrapper.setOptions(this.options || {});
 
-    this._setDrawn(false);
-    this.redrawDebouncer =
-        Debouncer.debounce(this.redrawDebouncer, timeOut.after(5), () => {
-          // Drawing happens after `chartWrapper` is initialized.
-          this.chartWrapper!.draw();
-        });
+    this.drawn = false;
+    if (this.redrawTimeoutId !== undefined) clearTimeout(this.redrawTimeoutId);
+    this.redrawTimeoutId = window.setTimeout(() => {
+      // Drawing happens after `chartWrapper` is initialized.
+      this.chartWrapper!.draw();
+    }, 5);
   }
 
   /**
@@ -470,15 +489,13 @@ export class GoogleChart extends PolymerElement {
   }
 
   /** Handles changes to the `view` attribute. */
-  protected viewChanged() {
-    if (!this.view) {
-      return;
-    }
+  private viewChanged() {
+    if (!this.view) return;
     this._data = this.view;
   }
 
   /** Handles changes to the rows & columns attributes. */
-  protected async rowsOrColumnsChanged() {
+  private async rowsOrColumnsChanged() {
     const {rows, cols} = this;
     if (!rows || !cols) return;
     try {
@@ -486,14 +503,14 @@ export class GoogleChart extends PolymerElement {
       dt.addRows(rows);
       this._data = dt;
     } catch (reason) {
-      this.$['chartdiv'].textContent = reason;
+      this.shadowRoot!.getElementById('chartdiv')!.textContent = reason;
     }
   }
 
   /**
    * Handles changes to the `data` attribute.
    */
-  protected dataChanged() {
+  private dataChanged() {
     let data = this.data;
     let dataPromise;
     if (!data) {
@@ -528,7 +545,7 @@ export class GoogleChart extends PolymerElement {
    * Queries global document head for Google Charts `link#load-css-*` and clones
    * them into the local root's `div#styles` element for shadow dom support.
    */
-  private localizeGlobalStylesheets() {
+  private localizeGlobalStylesheets(stylesDiv: HTMLElement) {
     // Get all Google Charts stylesheets.
     const stylesheets = Array.from(document.head.querySelectorAll(
         'link[rel="stylesheet"][type="text/css"][id^="load-css-"]'));
@@ -541,7 +558,7 @@ export class GoogleChart extends PolymerElement {
       // `href` is always present.
       clonedStylesheet.setAttribute('href', stylesheet.getAttribute('href')!);
 
-      this.$['styles'].appendChild(clonedStylesheet);
+      stylesDiv.appendChild(clonedStylesheet);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6604,6 +6604,19 @@
         "leven": "^3.1.0"
       }
     },
+    "lit-element": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
+      "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "lit-html": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
+      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -10451,9 +10464,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "web-component",
     "web-components",
     "polymer",
+    "lit-element",
     "chart",
     "charts",
     "google-visualization",
@@ -22,11 +23,12 @@
   "main": "google-chart.js",
   "module": "google-chart.js",
   "scripts": {
-    "start": "es-dev-server --app-index demo/index.html --node-resolve --open --watch",
-    "test": "wct --module-resolution=node --npm --simpleOutput -l chrome",
-    "pretest": "npm run build",
+    "prepare": "npm run build",
     "build": "tsc",
-    "prepare": "npm run build"
+    "build:watch": "tsc --watch",
+    "start": "es-dev-server --app-index demo/index.html --node-resolve --open --watch",
+    "pretest": "npm run build",
+    "test": "wct --module-resolution=node --npm --simpleOutput -l chrome"
   },
   "contributors": [
     "Wes Alvaro",
@@ -35,15 +37,16 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@polymer/decorators": "^3.0.0",
-    "@polymer/polymer": "^3.0.0"
+    "lit-element": "^2.3.1"
   },
   "devDependencies": {
+    "@polymer/decorators": "^3.0.0",
+    "@polymer/polymer": "^3.0.0",
     "@types/chai": "^4.2.11",
     "@types/google.visualization": "0.0.51",
     "@types/mocha": "^7.0.2",
     "es-dev-server": "^1.46.2",
-    "typescript": "^3.7.5",
+    "typescript": "^3.9.5",
     "wct-browser-legacy": "^1.0.2",
     "web-component-tester": "^6.9.2"
   }

--- a/test/custom-load-test.ts
+++ b/test/custom-load-test.ts
@@ -18,6 +18,7 @@
 import '../google-chart.js';
 import {GoogleChart} from '../google-chart.js';
 import {load} from '../loader.js';
+import {ready} from './helpers.js';
 
 const assert = chai.assert;
 
@@ -41,9 +42,8 @@ suite('Custom load', () => {
   test('loads packages for chart type="table"', async () => {
     const chart = fixture('type-table') as GoogleChart;
     chart.data = [ ['Data', 'Value'], ['Something', 1] ];
-    await new Promise((resolve) => {
-      chart.addEventListener('google-chart-ready', resolve);
-    });
-    assert.isAbove(chart.$['chartdiv'].childElementCount, 0);
+    await ready(chart);
+    const chartDiv = chart.shadowRoot!.getElementById('chartdiv')!;
+    assert.isAbove(chartDiv.childElementCount, 0);
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2014-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns a promise that resolves when drawing of the chart is finished. */
+export function ready(element: EventTarget): Promise<unknown> {
+  return new Promise(resolve => {
+    element.addEventListener('google-chart-ready', resolve, {once: true});
+  })
+}

--- a/test/polymer-use-test.html
+++ b/test/polymer-use-test.html
@@ -14,18 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-<title>Tests</title>
 <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
 
-<script>
-  // Load and run all tests (.html, .js) as one suite:
-  WCT.loadSuites([
-    'basic-tests.html?wc-shadydom=true&wc-ce=true',
-    'basic-tests.html?dom=shadow',
-    'custom-load-test.html',
-    'polymer-use-test.html',
-  ]);
-</script>
+<script type="module" src="polymer-use-test.js"></script>

--- a/test/polymer-use-test.ts
+++ b/test/polymer-use-test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2014-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../google-chart.js';
+import {customElement, property} from '@polymer/decorators';
+import {PolymerElement, html} from '@polymer/polymer';
+import {DataTableLike} from '../loader.js';
+import {ready} from './helpers.js';
+
+const assert = chai.assert;
+
+suite('<google-chart> use in Polymer element', () => {
+  let element: GoogleChartTestElement;
+  setup(async () => {
+    element = new GoogleChartTestElement();
+    document.body.append(element);
+    await ready(element);
+  });
+  teardown(() => {
+    element?.remove();
+  })
+  test('passes properties', () => {
+    const chartDiv =
+        element.$['chart'].shadowRoot!.getElementById('chartdiv')!;
+    assert.include(chartDiv.innerText, 'Value');
+    assert.include(chartDiv.innerText, 'Something');
+  });
+  test('deep options change via binding', async () => {
+    element.set('options.title', 'New title');
+    const chartDiv =
+        element.$['chart'].shadowRoot!.getElementById('chartdiv')!;
+    await ready(element);
+    assert.include(chartDiv.innerText, 'New title');
+  });
+});
+
+@customElement('google-chart-polymer-test')
+class GoogleChartTestElement extends PolymerElement {
+  static get template() {
+    return html`
+      <google-chart id="chart" options="[[options]]" data="[[data]]">
+      </google-chart>
+    `;
+  }
+
+  @property({type: Object})
+  options: google.visualization.ColumnChartOptions = {};
+
+  @property({type: Object})
+  data: DataTableLike = [
+    ['Data', 'Value'],
+    ['Something', 1],
+  ];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "es2015",
+    "target": "es2018",
+    "module": "esnext",
     "strict": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
@@ -9,6 +9,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "inlineSources": true
+    "inlineSources": true,
+    "esModuleInterop": false
   }
 }


### PR DESCRIPTION
- switch to LitElement base class without unifying Google Charts rendering
and LitElement lifecycle (#293)
- add backwards compatiblity for Polymer notifying property
- remove chart dependency on Polymer, but tests still use it
- options cannot be observed for sub-property changes, so trigger
redraw whenever the property is updated; updated tests to show how to
handle the change
- removed Polymer readOnly property; it is safe to use a regular
class field because it does not require checking for its updates
- update TypeScript and tsconfig following open-wc template (#280)
- create test helpers to wait for ready event
- test whether using the chart from a Polymer component works with data
bindings