### PR TITLE
Remove selection-changed event

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -380,18 +380,7 @@ export class GoogleChart extends LitElement {
     if (changedProperties.has('view')) this.viewChanged();
     if (changedProperties.has('_data') ||
         changedProperties.has('options')) this.redraw();
-    if (changedProperties.has('selection')) {
-      this.selectionChanged();
-      // Fire event for backwards compatibility with Polymer two-way data
-      // binding: `@property({notify: true})`.
-      this.dispatchEvent(new CustomEvent('selection-changed', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          'value': this.selection,
-        },
-      }));
-    }
+    if (changedProperties.has('selection')) this.selectionChanged();
   }
 
   /** Reacts to chart type change. */

--- a/test/polymer-use-test.ts
+++ b/test/polymer-use-test.ts
@@ -18,6 +18,7 @@
 import '../google-chart.js';
 import {customElement, property} from '@polymer/decorators';
 import {PolymerElement, html} from '@polymer/polymer';
+import {GoogleChart} from '../google-chart.js';
 import {DataTableLike} from '../loader.js';
 import {ready} from './helpers.js';
 
@@ -25,20 +26,24 @@ const assert = chai.assert;
 
 suite('<google-chart> use in Polymer element', () => {
   let element: GoogleChartTestElement;
+
   setup(async () => {
     element = new GoogleChartTestElement();
     document.body.append(element);
     await ready(element);
   });
+
   teardown(() => {
     element?.remove();
   })
+
   test('passes properties', () => {
     const chartDiv =
         element.$['chart'].shadowRoot!.getElementById('chartdiv')!;
     assert.include(chartDiv.innerText, 'Value');
     assert.include(chartDiv.innerText, 'Something');
   });
+
   test('deep options change via binding', async () => {
     element.set('options.title', 'New title');
     const chartDiv =
@@ -46,13 +51,33 @@ suite('<google-chart> use in Polymer element', () => {
     await ready(element);
     assert.include(chartDiv.innerText, 'New title');
   });
+
+  test('two-way binding', async () => {
+    // chart-selection-changed fires because the propery has {notify: true}.
+    const chartSelectionChanged = new Promise(resolve => {
+      element.addEventListener('chart-selection-changed', resolve, {once: true});
+    });
+    // Get chartWrapper and simulate user selection:
+    // https://developers.google.com/chart/interactive/docs/dev/events#firing-an-event
+    const chartWrapper: google.visualization.ChartWrapper=
+        (element.$['chart'] as GoogleChart)['chartWrapper']!;
+    chartWrapper.getChart().setSelection([{row: 1}]);
+    google.visualization.events.trigger(chartWrapper.getChart(), 'select', {});
+    await chartSelectionChanged;
+
+    assert.sameDeepMembers(element.chartSelection!, [{row: 1, column: null}]);
+  });
 });
 
 @customElement('google-chart-polymer-test')
 class GoogleChartTestElement extends PolymerElement {
   static get template() {
     return html`
-      <google-chart id="chart" options="[[options]]" data="[[data]]">
+      <google-chart
+          id="chart"
+          options="[[options]]"
+          data="[[data]]"
+          selection="{{chartSelection::google-chart-select}}">
       </google-chart>
     `;
   }
@@ -64,5 +89,10 @@ class GoogleChartTestElement extends PolymerElement {
   data: DataTableLike = [
     ['Data', 'Value'],
     ['Something', 1],
+    ['Thing', 2],
+    ['Entry', 3],
   ];
+
+  @property({type: Array, notify: true})
+  chartSelection: unknown[]|undefined;
 }


### PR DESCRIPTION
The `selection-changed` event is Polymer-specific. It is used for two-way bindings and fired when the selection property changes. There is also the `google-chart-select` event fired when the user selects something. This makes the former event redundant. It would also have slightly different timing in LitElement because of asynchronous rendering. The latter is chosen for consistency with other events: `google-chart-ready`, `google-chart-mouseover`, etc.

lit-html users should listen to selection updates using:
```
<google-chart .selection="${chartSelection}" @google-chart-select="${reactToChartSelection}"></google-chart>
```

Polymer users should update the two-way binding to:
```
<google-chart selection="{{chartSelection::google-chart-select}}"></google-chart>
```
Note the `::google-chart-select` part. https://polymer-library.polymer-project.org/3.0/docs/devguide/data-binding#two-way-native
