### PR TITLE
Add Gantt chart

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -549,6 +549,45 @@
              ["Zaire", "Africa", 8]]'>
   </google-chart>
 
+  <p>Here's a Gantt chart:</p>
+
+  <google-chart id="gantt-chart" type="gantt"></google-chart>
+
+  <script type="module">
+    import '../google-chart.js';
+    import {dataTable} from '../loader.js';
+    const chart = document.getElementById('gantt-chart');
+    dataTable().then((data) => {
+      // See https://developers.google.com/chart/interactive/docs/gallery/ganttchart
+      function daysToMilliseconds(days) {
+        return days * 24 * 60 * 60 * 1000;
+      }
+
+      data.addColumn('string', 'Task ID');
+      data.addColumn('string', 'Task Name');
+      data.addColumn('date', 'Start Date');
+      data.addColumn('date', 'End Date');
+      data.addColumn('number', 'Duration');
+      data.addColumn('number', 'Percent Complete');
+      data.addColumn('string', 'Dependencies');
+
+      data.addRows([
+        ['Research', 'Find sources',
+         new Date(2015, 0, 1), new Date(2015, 0, 5), null,  100,  null],
+        ['Write', 'Write paper',
+         null, new Date(2015, 0, 9), daysToMilliseconds(3), 25, 'Research,Outline'],
+        ['Cite', 'Create bibliography',
+         null, new Date(2015, 0, 7), daysToMilliseconds(1), 20, 'Research'],
+        ['Complete', 'Hand in paper',
+         null, new Date(2015, 0, 10), daysToMilliseconds(1), 0, 'Cite,Write'],
+        ['Outline', 'Outline paper',
+         null, new Date(2015, 0, 6), daysToMilliseconds(1), 100, 'Research']
+      ]);
+
+      chart.data = data;
+    });
+  </script>
+
   <p>Here is a chart using a DataTable as its source:</p>
 
   <google-chart

--- a/google-chart.ts
+++ b/google-chart.ts
@@ -36,6 +36,7 @@ const CHART_TYPES: Record<string, string|undefined> = {
   'candlestick': 'CandlestickChart',
   'column': 'ColumnChart',
   'combo': 'ComboChart',
+  'gantt': 'Gantt',
   'gauge': 'Gauge',
   'geo': 'GeoChart',
   'histogram': 'Histogram',
@@ -173,6 +174,7 @@ export class GoogleChart extends LitElement {
    * - `candlestick`
    * - `column`
    * - `combo`
+   * - `gantt`
    * - `gauge`
    * - `geo`
    * - `histogram`


### PR DESCRIPTION
Add Gantt charts to the list of available types. Also include a demo Gantt chart with the example from the Google Charts documentation.