### PR TITLE
Add type assertion to JSON.parse().

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -516,7 +516,7 @@ export class GoogleChart extends LitElement {
     try {
       // Try to deserialize the value of the `data` property which might be a
       // serialized array.
-      data = JSON.parse(data as string);
+      data = JSON.parse(data as string) as DataTableLike;
     } catch (e) {
       isString = typeof data === 'string' || data instanceof String;
     }


### PR DESCRIPTION
This makes this repo compliant with Bazel's TypeScript rules: https://github.com/bazelbuild/rules_typescript/blob/master/internal/tsetse/rules/must_type_assert_json_parse_rule.ts