### PR TITLE
Add typings key

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
     "typescript": "^3.9.5",
     "wct-browser-legacy": "^1.0.2",
     "web-component-tester": "^6.9.2"
-  }
+  },
+  "typings": "google-chart.d.ts"
 }


### PR DESCRIPTION
With this key, https://www.npmjs.com/package/@google-web-components/google-chart will be marked TypeScript icon. See https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/