### PR TITLE
bump(lit-element): new version 3.0.0 bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "lit-element": "^2.3.1"
+    "lit-element": "^3.0.0"
   },
   "devDependencies": {
     "@polymer/decorators": "^3.0.0",


### PR DESCRIPTION
# [Issue]()

# Description

LitHtml now has version 2.0.0 stable since then also `lit-element` is updated.
The purpose of this PR is to bump the version of `lit-element` to `3.0.0` accepting patches with `^` prefix

## Type of change

-   [x] Breaking change

# Checklist:

-   [x] Bumped version `lit-element` to `^3.0.0` inside `package.json`

