### PR TITLE
Update Lit packages and imports

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import {html, css, LitElement, property} from 'lit-element';
+import {html, css, LitElement} from 'lit';
+import {property} from 'lit/decorators.js';
 
 import {createChartWrapper, dataTable, DataTableLike} from './loader';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "lit-element": "^3.0.0"
+        "lit": "^2.0.2"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0.tgz",
-      "integrity": "sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3328,19 +3328,29 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/lit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
+      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
     "node_modules/lit-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0.tgz",
-      "integrity": "sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
+      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
         "lit-html": "^2.0.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0.tgz",
-      "integrity": "sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
+      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -5398,9 +5408,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0.tgz",
-      "integrity": "sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7995,19 +8005,29 @@
         }
       }
     },
+    "lit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
+      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
     "lit-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0.tgz",
-      "integrity": "sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
+      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
       "requires": {
         "@lit/reactive-element": "^1.0.0",
         "lit-html": "^2.0.0"
       }
     },
     "lit-html": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0.tgz",
-      "integrity": "sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
+      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "Rafal Slawik"
   ],
   "license": "Apache-2.0",
-  "dependencies": {
-    "lit-element": "^3.0.0"
-  },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@open-wc/testing": "^2.5.33",
@@ -59,5 +56,8 @@
     "sinon": "^11.1.2",
     "typescript": "^4.4.4"
   },
-  "typings": "google-chart.d.ts"
+  "typings": "google-chart.d.ts",
+  "dependencies": {
+    "lit": "^2.0.2"
+  }
 }


### PR DESCRIPTION
The main 'lit-element' module entrypoint is deprecated. Please update your imports to use the 'lit' package: 'lit' and 'lit/decorators.ts' or import from 'lit-element/lit-element.ts'. See https://lit.dev/msg/deprecated-import-path for more information.