### PR TITLE
Add .js to loader import

### DIFF
--- a/google-chart.ts
+++ b/google-chart.ts
@@ -18,7 +18,7 @@
 import {html, css, LitElement} from 'lit';
 import {property} from 'lit/decorators.js';
 
-import {createChartWrapper, dataTable, DataTableLike} from './loader';
+import {createChartWrapper, dataTable, DataTableLike} from './loader.js';
 
 const DEFAULT_EVENTS = ['ready', 'select'];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@web/dev-server": "^0.1.25",
         "@web/test-runner": "^0.13.20",
         "sinon": "^11.1.2",
-        "typescript": "^4.4.4"
+        "typescript": "^4.5.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4848,9 +4848,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9197,9 +9197,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@web/dev-server": "^0.1.25",
     "@web/test-runner": "^0.13.20",
     "sinon": "^11.1.2",
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.4"
   },
   "typings": "google-chart.d.ts",
   "dependencies": {


### PR DESCRIPTION
The import should use a full path - https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#type-in-packagejson-and-new-extensions.

Also bump TypeScript version.

Fixes #322 