### PR TITLE
Use safevalues library to safely set script source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^2.6.1"
+        "lit": "^2.6.1",
+        "safevalues": "^0.4.3"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -3240,6 +3241,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/safevalues": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.4.3.tgz",
+      "integrity": "sha512-pNCNTkx3xs7G5YJ/9CoeZZVUSPRjH0SEPM0QI5Z1FZRlLBviTFWlNKPs8PTvZvERV0gO7ie/t/Zc0S96JS4Xew=="
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -6365,6 +6371,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "safevalues": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.4.3.tgz",
+      "integrity": "sha512-pNCNTkx3xs7G5YJ/9CoeZZVUSPRjH0SEPM0QI5Z1FZRlLBviTFWlNKPs8PTvZvERV0gO7ie/t/Zc0S96JS4Xew=="
     },
     "semver": {
       "version": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "typings": "google-chart.d.ts",
   "dependencies": {
-    "lit": "^2.6.1"
+    "lit": "^2.6.1",
+    "safevalues": "^0.4.3"
   }
 }


### PR DESCRIPTION
This also allows removing the bespoke compatibility code with Trusted Types and nonce-based CSP, which safevalues already takes care of.